### PR TITLE
Fix broken air sensors homepage

### DIFF
--- a/src/pages/air/AirHome.js
+++ b/src/pages/air/AirHome.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 
-import Grid from '@material-ui/core/Grid';
 import Navbar from '../../components/Header/Navbar';
 import Stories from '../../components/About/Stories';
 import Support from '../../components/Support';
@@ -13,7 +12,7 @@ import AirHeader from '../../components/AirComponents/AirHeader';
 class AirHome extends Component {
     render() {
         return (
-            <Grid container item xs={12}>
+            <React.Fragment>
                 <Navbar />
                 <AirHeader />
                 <Issues />
@@ -21,7 +20,7 @@ class AirHome extends Component {
                 <Stories />
                 <Support />
                 <Footer />
-            </Grid>
+            </React.Fragment>
         );
     }
 }


### PR DESCRIPTION
## Description

The current air sensors homepage is broken in Firefox. This PR fixes that.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Screenshots

### Before

![screenshot from 2018-10-03 15-16-08](https://user-images.githubusercontent.com/1779590/46410004-0f0a1500-c720-11e8-8d98-867b0184fc1f.png)

### After

![screenshot from 2018-10-03 15-20-55](https://user-images.githubusercontent.com/1779590/46410013-16c9b980-c720-11e8-832b-22508de74ec3.png)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation