### PR TITLE
Showcase Hover Height Fix

### DIFF
--- a/src/components/Showcase/StoryCard.js
+++ b/src/components/Showcase/StoryCard.js
@@ -31,7 +31,8 @@ const styles = theme => ({
   },
   media: {
     height: 0,
-    paddingTop: '56.25%'
+    paddingTop: '56.25%',
+    width: '100%'
   },
   cardLink: {
     textDecoration: 'none'
@@ -61,9 +62,11 @@ function StoryCard({ story, classes }) {
         rel="noopener noreferrer"
         className={classes.cardLink}
       >
-        <CardActionArea>
+        <CardActionArea
+          style={{ display: 'flex', flexFlow: 'column', height: '100%' }}
+        >
           <CardMedia className={classes.media} image={image} title=" Story" />
-          <CardContent>
+          <CardContent style={{ flexGrow: 1 }}>
             <Typography variant="h5" className={classes.overline}>
               {date}
             </Typography>

--- a/src/components/Showcase/StoryList.js
+++ b/src/components/Showcase/StoryList.js
@@ -61,7 +61,7 @@ function StoryList(props) {
     <Grid
       container
       justify="center"
-      alignitems="center"
+      alignItems="center"
       className={classes.root}
     >
       <Grid item xs={12} container justify="center" alignItems="center">


### PR DESCRIPTION
## Description

Make `CardActionArea` 100% height of the `Card`.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Screenshots

### Before

![screenshot from 2019-02-05 11-11-31](https://user-images.githubusercontent.com/1779590/52260908-a4b8e980-2938-11e9-8860-cc5b8b6dfd31.png)

### After

![screenshot from 2019-02-05 11-11-52](https://user-images.githubusercontent.com/1779590/52260914-a97d9d80-2938-11e9-924a-2362d952ca4a.png)


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas