### PR TITLE
Refresh map on city change

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -75,7 +75,7 @@ const CITIES_LOCATION = {
     country: 'Tanzania',
     label: 'Dar-es-salaam, Tanzania',
     zoom: '12',
-    center: '-6.8555,39.1518',
+    center: '-6.7846,39.2669',
     twitterHandle: '#DarEsSalaam'
   }
 };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -52,7 +52,8 @@ const CITIES_LOCATION = {
     name: 'Nairobi',
     country: 'Kenya',
     label: 'Nairobi, Kenya',
-    location: '12/-1.2709/36.8169',
+    zoom: '12',
+    center: '-1.2709,36.8169',
     twitterHandle: '@nairobicitygov'
   },
   lagos: {
@@ -62,7 +63,8 @@ const CITIES_LOCATION = {
     name: 'Lagos',
     country: 'Nigeria',
     label: 'Lagos, Nigeria',
-    location: '12/6.4552/3.4198',
+    zoom: '12',
+    center: '6.4552,3.4198',
     twitterHandle: '@followlasg'
   },
   'dar-es-salaam': {
@@ -72,7 +74,8 @@ const CITIES_LOCATION = {
     name: 'Dar es Salaam',
     country: 'Tanzania',
     label: 'Dar-es-salaam, Tanzania',
-    location: '12/-6.8555/39.1518',
+    zoom: '12',
+    center: '-6.8555,39.1518',
     twitterHandle: '#DarEsSalaam'
   }
 };

--- a/src/components/Embeds/AirMap.js
+++ b/src/components/Embeds/AirMap.js
@@ -8,7 +8,9 @@ function AirMap({ location }) {
   const city = params.get('city');
   return (
     <iframe
-      src={`https://map.aq.sensors.africa/#${CITIES_LOCATION[city].location}`}
+      src={`https://map.aq.sensors.africa/?zoom=${
+        CITIES_LOCATION[city].zoom
+      }&center=${CITIES_LOCATION[city].center}`}
       name={`sensors-map-${CITIES_LOCATION[city].slug}`}
       title={`sensors.AFRICA | ${CITIES_LOCATION[city].name} Sensor Map`}
       scrolling="no"

--- a/src/components/SensorMap/index.js
+++ b/src/components/SensorMap/index.js
@@ -23,8 +23,7 @@ const styles = theme => ({
   }
 });
 
-function Map({ classes, mapLocation }) {
-  const src = `//map.aq.sensors.africa/#${mapLocation}`;
+function Map({ classes, zoom, center }) {
   return (
     <Grid
       container
@@ -43,7 +42,7 @@ function Map({ classes, mapLocation }) {
       <Grid item xs={12}>
         <IframeComponent
           title="Map section"
-          src={src}
+          src={`//map.aq.sensors.africa/?zoom=${zoom}&center=${center}`}
           height="500"
           width="100%"
           frameBorder="0"
@@ -56,6 +55,7 @@ function Map({ classes, mapLocation }) {
 
 Map.propTypes = {
   classes: PropTypes.object.isRequired,
-  mapLocation: PropTypes.string.isRequired
+  zoom: PropTypes.string.isRequired,
+  center: PropTypes.string.isRequired
 };
 export default withStyles(styles)(Map);

--- a/src/pages/air/City.js
+++ b/src/pages/air/City.js
@@ -263,7 +263,10 @@ class City extends React.Component {
           />
         </Grid>
         <Grid item xs={12} id="map">
-          <SensorMap mapLocation={CITIES_LOCATION[city].location} />
+          <SensorMap
+            zoom={CITIES_LOCATION[city].zoom}
+            center={CITIES_LOCATION[city].center}
+          />
         </Grid>
         <Grid item xs={12}>
           <QualityStats


### PR DESCRIPTION
## Description

Load map by query instead of hash since state updates seem to not update the hexLayer canvas position.

Leaflet HashMap and HexLayer are not working together properly so the issue will be resolved later. This will serve as a patch.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation