### PR TITLE
Style gauge chart to show outer green stroke line

### DIFF
--- a/src/components/Air/GaugeChart.js
+++ b/src/components/Air/GaugeChart.js
@@ -9,14 +9,19 @@ const styles = theme => ({
     maxWidth: '100%',
     margin: 'auto'
   },
-  circularChartWhiteCircle: {
+  circularChartGreenCircle: {
     display: 'block',
-    stroke: '#fff'
+    stroke: '#2FB56B'
+  },
+  circleOuter: {
+    fill: 'none',
+    stroke: '#2FB56B',
+    strokeWidth: '3.4'
   },
   circleBg: {
     fill: 'none',
-    stroke: '#2FB56B',
-    strokeWidth: '4.4'
+    stroke: '#fff',
+    strokeWidth: '2.4'
   },
   percentage: {
     fill: '#666',
@@ -29,7 +34,7 @@ const styles = theme => ({
   },
   circle: {
     fill: 'none',
-    strokeWidth: '3.8',
+    strokeWidth: '1.8',
     strokeLinecap: 'none',
     animation: 'progress 1s ease-out forwards'
   },
@@ -45,14 +50,22 @@ function GaugeChart(props) {
   return (
     <svg
       viewBox="0 0 37 37"
-      className={(classes.circularChart, classes.circularChartWhiteCircle)}
+      className={(classes.circularChart, classes.circularChartGreenCircle)}
     >
       <path
-        className={classes.circleBg}
+        className={classes.circleOuter}
         d="M18 2.0845
             a 15.9155 15.9155 0 0 1 0 31.831
             a 15.9155 15.9155 0 0 1 0 -31.831"
       />
+
+      <path
+        className={classes.circleBg}
+        d="M18 2.0845
+            a 14.9155 14.9155 0 0 1 0 31.831
+            a 14.9155 14.9155 0 0 1 0 -31.831"
+      />
+
       <path
         className={classes.circle}
         strokeDasharray={`${percentage} 100`}
@@ -60,6 +73,7 @@ function GaugeChart(props) {
             a 15.9155 15.9155 0 0 1 0 31.831
             a 15.9155 15.9155 0 0 1 0 -31.831"
       />
+
       <text x="18" y="20.35" className={classes.percentage}>
         {percentage}%
       </text>

--- a/src/components/Air/GaugeChart.js
+++ b/src/components/Air/GaugeChart.js
@@ -24,7 +24,7 @@ const styles = theme => ({
     stroke: '#666',
     strokeWidth: '0.25',
     fontFamily: theme.typography.fontFamily,
-    fontWeight: 500,
+    fontWeight: 600,
     fontSize: '0.35em',
     textAnchor: 'middle'
   },
@@ -49,8 +49,6 @@ function GaugeChart(props) {
   return (
     <svg
       viewBox="-2 -2 40 40"
-      width="180"
-      height="180"
       className={(classes.circularChart, classes.circularChartWhiteCircle)}
     >
       <path

--- a/src/components/Air/GaugeChart.js
+++ b/src/components/Air/GaugeChart.js
@@ -9,19 +9,14 @@ const styles = theme => ({
     maxWidth: '100%',
     margin: 'auto'
   },
-  circularChartGreenCircle: {
+  circularChartWhiteCircle: {
     display: 'block',
-    stroke: '#2FB56B'
-  },
-  circleOuter: {
-    fill: 'none',
-    stroke: '#2FB56B',
-    strokeWidth: '3.4'
+    stroke: '#fff'
   },
   circleBg: {
     fill: 'none',
-    stroke: '#fff',
-    strokeWidth: '2.4'
+    stroke: '#2FB56B',
+    strokeWidth: '4.4'
   },
   percentage: {
     fill: '#666',
@@ -34,13 +29,16 @@ const styles = theme => ({
   },
   circle: {
     fill: 'none',
-    strokeWidth: '1.8',
+    strokeWidth: '3.8',
     strokeLinecap: 'none',
     animation: 'progress 1s ease-out forwards'
   },
   '@keyframes progress': {
-    '0%': {
-      strokeDasharray: '0 100'
+    from: {
+      strokeDashoffset: '100'
+    },
+    to: {
+      strokeDashoffset: '200'
     }
   }
 });
@@ -50,30 +48,21 @@ function GaugeChart(props) {
   return (
     <svg
       viewBox="0 0 37 37"
-      className={(classes.circularChart, classes.circularChartGreenCircle)}
+      className={(classes.circularChart, classes.circularChartWhiteCircle)}
     >
-      <path
-        className={classes.circleOuter}
-        d="M18 2.0845
-            a 15.9155 15.9155 0 0 1 0 31.831
-            a 15.9155 15.9155 0 0 1 0 -31.831"
-      />
-
       <path
         className={classes.circleBg}
         d="M18 2.0845
-            a 14.9155 14.9155 0 0 1 0 31.831
-            a 14.9155 14.9155 0 0 1 0 -31.831"
+            a 15.9155 15.9155 0 0 1 0 31.831
+            a 15.9155 15.9155 0 0 1 0 -31.831"
       />
-
       <path
         className={classes.circle}
-        strokeDasharray={`${percentage} 100`}
+        strokeDasharray={`200 ${percentage}`}
         d="M18 2.0845
             a 15.9155 15.9155 0 0 1 0 31.831
             a 15.9155 15.9155 0 0 1 0 -31.831"
       />
-
       <text x="18" y="20.35" className={classes.percentage}>
         {percentage}%
       </text>

--- a/src/components/Air/GaugeChart.js
+++ b/src/components/Air/GaugeChart.js
@@ -11,12 +11,13 @@ const styles = theme => ({
   },
   circularChartWhiteCircle: {
     display: 'block',
-    stroke: '#fff'
+    stroke: '#fff',
+    margin: 'auto'
   },
   circleBg: {
     fill: 'none',
     stroke: '#2FB56B',
-    strokeWidth: '4.4'
+    strokeWidth: '7.4'
   },
   percentage: {
     fill: '#666',
@@ -29,7 +30,7 @@ const styles = theme => ({
   },
   circle: {
     fill: 'none',
-    strokeWidth: '3.8',
+    strokeWidth: '4.8',
     strokeLinecap: 'none',
     animation: 'progress 1s ease-out forwards'
   },
@@ -47,7 +48,9 @@ function GaugeChart(props) {
   const { classes, percentage } = props;
   return (
     <svg
-      viewBox="0 0 37 37"
+      viewBox="-2 -2 40 40"
+      width="180"
+      height="180"
       className={(classes.circularChart, classes.circularChartWhiteCircle)}
     >
       <path

--- a/src/components/Air/HealthEffects.js
+++ b/src/components/Air/HealthEffects.js
@@ -28,11 +28,20 @@ function HealthEffects({ classes }) {
       className={classes.svgContainer}
       justify="center"
       alignItems="flex-start"
+      spacing={2}
     >
-      <Gauge percentage={36} caption="of lung cancer deaths" />
-      <Gauge percentage={34} caption="of stroke deaths" />
-      <Gauge percentage={27} caption="of heart disease deaths" />
-      <Gauge percentage={35} caption="of COPD (pulmonary disease deaths)" />
+      <Grid item>
+        <Gauge percentage={36} caption="of lung cancer deaths" />
+      </Grid>
+      <Grid item>
+        <Gauge percentage={34} caption="of stroke deaths" />
+      </Grid>
+      <Grid item>
+        <Gauge percentage={27} caption="of heart disease deaths" />
+      </Grid>
+      <Grid item>
+        <Gauge percentage={35} caption="of COPD (pulmonary disease deaths)" />
+      </Grid>
     </Grid>
   );
 }


### PR DESCRIPTION
## Description

On the gauge chart component, i have styled the gauge to show the outer green stroke-line
However there is a challenge on making the `stroke-line` thick so that it's well presented, The resolution to this is redesigning the gauge component separately so that you have control of `stroke-width`. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
<img width="1680" alt="Screen Shot 2020-03-05 at 18 34 30" src="https://user-images.githubusercontent.com/6592749/75997877-0ae3b780-5f11-11ea-8035-9b2726f63bff.png">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation