### PR TITLE
[Fix] FontAwesome Icon Sizes

### DIFF
--- a/src/components/City/HostSensors/ShareButton/SocialMediaButtons.js
+++ b/src/components/City/HostSensors/ShareButton/SocialMediaButtons.js
@@ -5,13 +5,18 @@ import PropTypes from "prop-types";
 import React from "react";
 import { TwitterShareButton } from "react-share";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(({ typography }) => ({
   twitter: { backgroundColor: "#00aced", margin: "0.2rem" },
   facebook: { backgroundColor: "#3b5998", margin: "0.2rem" },
   instagram: { backgroundColor: "#8a3ab9", margin: "0.2rem" },
   medium: { backgroundColor: "#00ab6c", margin: "0.2rem" },
-  fa: { color: "white", margin: "0.2rem" },
-});
+  fa: {
+    color: "white",
+    height: typography.pxToRem(28),
+    margin: "0.2rem",
+    width: typography.pxToRem(28),
+  },
+}));
 
 function SocialMediaButtons({ city }) {
   const classes = useStyles();

--- a/src/components/Hambuger/MenuButton.js
+++ b/src/components/Hambuger/MenuButton.js
@@ -2,7 +2,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import PropTypes from "prop-types";
 import React from "react";
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(({ breakpoints, spacing }) => ({
   container: {
     height: 32,
     width: 32,
@@ -10,10 +10,15 @@ const useStyles = makeStyles(() => ({
     flexDirection: "column",
     justifyContent: "center",
     alignItems: "center",
+    marginRight: 8,
     cursor: "pointer",
-    padding: 4,
+    padding: spacing(0.5),
     zIndex: "1301",
     position: "relative",
+    [breakpoints.up("md")]: {
+      marginLeft: 4,
+      marginRight: 0,
+    },
   },
 }));
 

--- a/src/components/Header/Navbar.js
+++ b/src/components/Header/Navbar.js
@@ -99,54 +99,59 @@ function Navbar(props) {
         {/* Position sticky is not universally supported so the attribute reverts to static when unavailable */}
         <AppBar position="fixed" className={classes.appBar}>
           <Toolbar className={classes.toolbar} disableGutters>
-            <div className={classes.logoGrid}>
-              <IconLogo />
-            </div>
             <Grid
               container
               direction="row"
-              justifyContent="flex-start"
+              justifyContent="space-between"
               alignItems="center"
-              className={classes.linkGrid}
+              // className={classes.linkGrid}
             >
-              <MenuItem className={classes.airText}>
-                <Link href="/air" className={classes.airlink}>
-                  AIR
-                </Link>
-              </MenuItem>
+              <Grid item>
+                <Grid container>
+                  <div className={classes.logoGrid}>
+                    <IconLogo />
+                  </div>
+                  <MenuItem className={classes.airText}>
+                    <Link href="/air" className={classes.airlink}>
+                      AIR
+                    </Link>
+                  </MenuItem>
 
-              <MenuItem className={classes.waterText}>
-                <Link href="/water" className={classes.waterlink}>
-                  WATER
-                </Link>
-              </MenuItem>
-              <MenuItem className={classes.soundText}>
-                <Link href="/sound" className={classes.soundlink}>
-                  SOUND
-                </Link>
-              </MenuItem>
-              <MenuItem className={classes.radiationText}>
-                <Link href="/radiation" className={classes.radiationlink}>
-                  RADIATION
-                </Link>
-              </MenuItem>
-            </Grid>
-
-            <Hidden smDown>
-              <Grid
-                container
-                direction="row"
-                justifyContent="flex-end"
-                alignItems="center"
-                className={classes.mediaGrid}
-              >
-                <Grid item>
-                  <SocialMedia color="#2FB56B" />
+                  <MenuItem className={classes.waterText}>
+                    <Link href="/water" className={classes.waterlink}>
+                      WATER
+                    </Link>
+                  </MenuItem>
+                  <MenuItem className={classes.soundText}>
+                    <Link href="/sound" className={classes.soundlink}>
+                      SOUND
+                    </Link>
+                  </MenuItem>
+                  <MenuItem className={classes.radiationText}>
+                    <Link href="/radiation" className={classes.radiationlink}>
+                      RADIATION
+                    </Link>
+                  </MenuItem>
                 </Grid>
               </Grid>
-            </Hidden>
-            <Grid item>
-              <MenuBar />
+
+              <Grid item>
+                <Grid
+                  item
+                  container
+                  alignItems="center"
+                  justifyContent="flex-end"
+                >
+                  <Hidden smDown>
+                    <Grid item>
+                      <SocialMedia color="#2FB56B" />
+                    </Grid>
+                  </Hidden>
+                  <Grid item>
+                    <MenuBar />
+                  </Grid>
+                </Grid>
+              </Grid>
             </Grid>
           </Toolbar>
         </AppBar>

--- a/src/components/SocialMedia.js
+++ b/src/components/SocialMedia.js
@@ -4,17 +4,19 @@ import { makeStyles } from "@material-ui/core/styles";
 import PropTypes from "prop-types";
 import React from "react";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   root: {
     flexGrow: 1,
     color: "white",
-    backgroundColor: theme.palette.secondary.main,
-    paddingTop: theme.spacing(1),
-    paddingBottom: theme.spacing(2),
+    backgroundColor: palette.secondary.main,
+    paddingTop: spacing(1),
+    paddingBottom: spacing(2),
   },
   fa: {
+    height: typography.pxToRem(28),
+    padding: spacing(0.5),
     transition: "all .5s ease-in-out",
-    padding: theme.spacing(0.5),
+    width: typography.pxToRem(28),
     "&:hover": {
       transform: "scale(1.3)",
       color: "#f3f3f3",

--- a/src/components/Support.js
+++ b/src/components/Support.js
@@ -95,8 +95,10 @@ const useStyles = makeStyles((theme) => ({
     textDecoration: "none",
   },
   fa: {
-    transition: "all .5s ease-in-out",
+    height: theme.typography.pxToRem(28),
     padding: theme.spacing(0.5),
+    transition: "all .5s ease-in-out",
+    width: theme.typography.pxToRem(28),
     "&:hover": {
       transform: "scale(1.3)",
       color: "#f3f33",


### PR DESCRIPTION
## Description

Seems like FontAwesome no longer take default SVG icons sizes and we have to explicitly set on.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![S](https://user-images.githubusercontent.com/1779590/155668787-036496b2-ae56-4e91-8a00-604c34bcadb3.jpg)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

