### PR TITLE
fix: Apply Correct API URL format for city selection in CityMenuBar

### DIFF
--- a/src/pages/air/city/[id].js
+++ b/src/pages/air/city/[id].js
@@ -165,7 +165,7 @@ function City({ city: citySlug, data, ...props }) {
       setCityP2Stats({ average: "--", averageDescription: "loading" });
       setCityTemperatureStats({});
       setCityHumidityStats({});
-      fetch(`/api/air-quality?city${city}`)
+      fetch(`/api/air/quality?city=${city}`)
         .then((res) => res.json())
         .then((json) => {
           setCityHumidityStats(getFormattedHumidityStats(json));
@@ -173,7 +173,7 @@ function City({ city: citySlug, data, ...props }) {
           setCityTemperatureStats(getFormattedTemperatureStats(json));
         })
         .then(() =>
-          fetch(`/api/weekly-p2-data?city${city}`)
+          fetch(`/api/air/weekly-p2-data?city=${city}`)
             .then((res) => res.json())
             .then((json) =>
               setCityP2WeeklyStats(getFormattedWeeklyP2Stats(json)),


### PR DESCRIPTION
## Description
This PR  includes changes to the `src/pages/air/city/[id].js` file to correct the API endpoint URLs for fetching air quality data when selecting a city from the `CityMenuBar` component. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
![Screen Recording 2024-11-26 at 15 39 03](https://github.com/user-attachments/assets/c6851cc4-59a1-42e8-80da-1352c5883ac9)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
