### PR TITLE
Redesign prototype: editorial "data as testimony" concept

### DIFF
--- a/redesign/.gitignore
+++ b/redesign/.gitignore
@@ -1,0 +1,2 @@
+# Verification screenshots (build artifacts)
+.preview-*.png

--- a/redesign/about.html
+++ b/redesign/about.html
@@ -1,0 +1,691 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>About — sensors.AFRICA</title>
+<meta name="description" content="sensors.AFRICA is a pan-African citizen science initiative that uses sensors to monitor air, water and sound pollution to give citizens actionable information about their cities.">
+
+<!-- Fonts: Fraunces (display serif) · Space Grotesk (data) · Inter (body) -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Space+Grotesk:wght@400;500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+
+<style>
+/* ============================================================
+   TOKENS — shared with all subpages, do not diverge
+   ============================================================ */
+:root{
+  --ink:#0c0f16; --ink-2:#141821; --ink-3:#1a1f2b;
+  --paper:#f1eee7; --paper-ink:#17140f;
+  --text:#e9ebf0; --text-2:#9aa2b1; --muted:#6b7280;
+  --hair:rgba(255,255,255,0.09); --hair-strong:rgba(255,255,255,0.16);
+  --aqi-good:#46d17f; --aqi-moderate:#f4c542; --aqi-sensitive:#f5822e;
+  --aqi-unhealthy:#ef5350; --aqi-veryunhealthy:#b06ae0; --aqi-hazardous:#c0466c;
+  --serif:"Fraunces",Georgia,serif;
+  --sans:"Inter",system-ui,-apple-system,sans-serif;
+  --data:"Space Grotesk","Inter",system-ui,sans-serif;
+  --maxw:1200px;
+}
+
+/* ============================================================
+   BASE
+   ============================================================ */
+*{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  background:var(--ink); color:var(--text);
+  font-family:var(--sans); font-size:16px; line-height:1.6;
+  -webkit-font-smoothing:antialiased;
+}
+img{max-width:100%;display:block}
+a{color:inherit}
+:focus-visible{outline:2px solid var(--aqi-moderate);outline-offset:3px;border-radius:2px}
+::selection{background:var(--aqi-sensitive);color:var(--ink)}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
+.kicker{
+  font-family:var(--data);font-size:.75rem;font-weight:500;
+  letter-spacing:.18em;text-transform:uppercase;color:var(--text-2);
+}
+.section-head{display:flex;align-items:baseline;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-bottom:8px}
+h2.display{
+  font-family:var(--serif);font-weight:600;font-size:clamp(1.7rem,3.4vw,2.6rem);
+  line-height:1.12;letter-spacing:-.01em;margin:10px 0 14px;
+}
+.lede{color:var(--text-2);max-width:56ch}
+
+/* The AQI spine — a segmented band used as the page's structural accent */
+.aqi-spine{display:flex;height:4px;width:100%}
+.aqi-spine span{flex:1}
+.aqi-spine .s1{background:var(--aqi-good)}
+.aqi-spine .s2{background:var(--aqi-moderate)}
+.aqi-spine .s3{background:var(--aqi-sensitive)}
+.aqi-spine .s4{background:var(--aqi-unhealthy)}
+.aqi-spine .s5{background:var(--aqi-veryunhealthy)}
+.aqi-spine .s6{background:var(--aqi-hazardous)}
+.spine-sm{width:64px;height:4px;margin-bottom:14px}
+
+/* ============================================================
+   HEADER
+   ============================================================ */
+.site-header{
+  position:sticky;top:0;z-index:1000;
+  background:rgba(12,15,22,.88);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+  border-bottom:1px solid var(--hair);
+}
+.header-inner{
+  max-width:var(--maxw);margin:0 auto;padding:0 24px;
+  display:flex;align-items:center;justify-content:space-between;gap:20px;height:64px;
+}
+.wordmark{
+  font-family:var(--data);font-weight:700;font-size:1.05rem;letter-spacing:.01em;
+  text-decoration:none;white-space:nowrap;
+}
+.wordmark .dot-africa{color:var(--aqi-good)}
+.main-nav{display:flex;gap:2px;align-items:center;overflow-x:auto}
+.main-nav a{
+  font-family:var(--data);font-size:.82rem;font-weight:500;color:var(--text-2);
+  text-decoration:none;padding:8px 11px;border-radius:6px;white-space:nowrap;
+}
+.main-nav a:hover{color:var(--text);background:var(--ink-3)}
+.main-nav a.live-link{color:var(--text)}
+.main-nav a.live-link::before{
+  content:"";display:inline-block;width:6px;height:6px;border-radius:50%;
+  background:var(--aqi-good);margin-right:7px;vertical-align:1px;
+}
+.main-nav a[aria-current="page"]{color:var(--text);background:var(--ink-3)}
+.nav-cta{
+  font-family:var(--data);font-size:.82rem;font-weight:700;text-decoration:none;
+  color:var(--ink);background:var(--aqi-good);padding:9px 16px;border-radius:999px;white-space:nowrap;
+}
+.nav-cta:hover{background:#5fdd92}
+
+/* ============================================================
+   BUTTONS (shared)
+   ============================================================ */
+.btn{
+  font-family:var(--data);font-weight:700;font-size:.92rem;text-decoration:none;
+  padding:13px 24px;border-radius:999px;display:inline-block;
+}
+.btn-primary{background:var(--aqi-good);color:var(--ink)}
+.btn-primary:hover{background:#5fdd92}
+.btn-ghost{color:var(--text);border:1px solid var(--hair-strong)}
+.btn-ghost:hover{border-color:var(--text-2)}
+.proto-badge{
+  display:inline-flex;align-items:center;gap:7px;margin-top:26px;
+  font-family:var(--data);font-size:.68rem;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--muted);border:1px solid var(--hair);border-radius:999px;padding:5px 12px;
+}
+.proto-badge::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--aqi-moderate)}
+
+/* ============================================================
+   EDITORIAL HERO
+   ============================================================ */
+.about-hero{position:relative;overflow:hidden;border-bottom:1px solid var(--hair)}
+.about-hero::before{
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:
+    radial-gradient(52rem 30rem at 78% -10%, rgba(245,130,46,.09), transparent 60%),
+    radial-gradient(44rem 26rem at 8% 110%, rgba(70,209,127,.06), transparent 60%);
+}
+.about-hero .hero-inner{position:relative;max-width:820px;padding:88px 0 76px}
+.about-hero h1{
+  font-family:var(--serif);font-weight:640;font-variation-settings:"opsz" 100;
+  font-size:clamp(2.4rem,5.2vw,4rem);line-height:1.06;letter-spacing:-.015em;margin-top:14px;
+}
+.about-hero h1 .dot-africa{color:var(--aqi-good)}
+.about-hero .mission{
+  margin-top:24px;font-family:var(--serif);font-weight:460;font-style:italic;
+  font-size:clamp(1.15rem,2.2vw,1.45rem);line-height:1.5;color:var(--text-2);max-width:56ch;
+}
+
+/* ============================================================
+   PAPER — long-form reading surface
+   ============================================================ */
+.section{padding:84px 0}
+.paper-section{background:var(--paper);color:var(--paper-ink)}
+.paper-section .kicker{color:#6d675c}
+.paper-section h2.display{color:var(--paper-ink)}
+.paper-section .lede{color:#4d473c}
+.story-cols{display:grid;grid-template-columns:minmax(0,1.15fr) minmax(0,.85fr);gap:56px;align-items:start;margin-top:20px}
+.story-prose{font-family:var(--serif);font-size:1.16rem;line-height:1.72;color:#2c2820;font-weight:420}
+.story-prose p+p{margin-top:1.1em}
+.story-prose strong{font-weight:640;color:var(--paper-ink)}
+.story-aside{display:flex;flex-direction:column;gap:14px}
+.fact-card{background:#fff;border:1px solid #e2ddd1;border-radius:12px;padding:20px 20px 18px}
+.fact-card .fk{
+  font-family:var(--data);font-size:.64rem;font-weight:700;letter-spacing:.16em;
+  text-transform:uppercase;color:#8a8375;margin-bottom:8px;
+}
+.fact-card .fv{font-family:var(--serif);font-weight:600;font-size:1.08rem;line-height:1.4;color:var(--paper-ink)}
+.fact-card .fv a{color:var(--paper-ink);text-decoration-color:#c9c2b2;text-underline-offset:3px}
+.fact-card .fv a:hover{text-decoration-color:var(--paper-ink)}
+.fact-card .fs{font-size:.82rem;color:#6d675c;margin-top:6px;line-height:1.5}
+.fact-card .fbar{height:4px;border-radius:2px;margin-top:14px}
+.paper-credit{margin-top:34px;font-family:var(--data);font-size:.74rem;color:#8a8375}
+
+/* ============================================================
+   PROJECTS — three cards
+   ============================================================ */
+.projects-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-top:34px}
+.project-card{
+  position:relative;display:flex;flex-direction:column;text-decoration:none;
+  background:var(--ink-2);border:1px solid var(--hair);border-radius:14px;
+  padding:26px 24px 24px;overflow:hidden;transition:transform .2s ease,border-color .2s ease;
+}
+.project-card:hover{transform:translateY(-3px);border-color:var(--hair-strong)}
+.project-card .accent{position:absolute;top:0;left:0;right:0;height:3px}
+.project-card .p-tag{
+  font-family:var(--data);font-size:.64rem;font-weight:700;letter-spacing:.2em;
+  text-transform:uppercase;color:var(--text-2);margin-bottom:14px;
+}
+.project-card h3{font-family:var(--serif);font-size:1.4rem;font-weight:600;margin-bottom:9px}
+.project-card p{font-size:.9rem;color:var(--text-2);flex:1}
+.project-card .p-foot{
+  margin-top:18px;font-family:var(--data);font-size:.74rem;color:var(--muted);
+  display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+}
+.project-card .p-stat{
+  font-family:var(--data);font-size:.7rem;font-weight:700;letter-spacing:.1em;text-transform:uppercase;
+  border:1px solid var(--hair-strong);border-radius:999px;padding:4px 11px;color:var(--text);
+}
+
+/* ============================================================
+   PARTNERS
+   ============================================================ */
+.backers-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:14px;margin-top:26px}
+.backer-card{background:#fff;border:1px solid #e2ddd1;border-radius:12px;padding:22px 22px 20px;text-decoration:none;display:block;transition:transform .2s ease,border-color .2s ease}
+.backer-card:hover{transform:translateY(-2px);border-color:#c9c2b2}
+.backer-card .bk{
+  font-family:var(--data);font-size:.64rem;font-weight:700;letter-spacing:.16em;
+  text-transform:uppercase;color:#8a8375;margin-bottom:8px;
+}
+.backer-card .bn{font-family:var(--serif);font-weight:640;font-size:1.35rem;color:var(--paper-ink)}
+.backer-card .bs{font-size:.84rem;color:#6d675c;margin-top:7px;line-height:1.5}
+.media-title{
+  margin-top:44px;font-family:var(--data);font-size:.66rem;font-weight:700;
+  letter-spacing:.18em;text-transform:uppercase;color:#8a8375;
+}
+.media-grid{
+  margin-top:16px;display:grid;grid-template-columns:repeat(4,1fr);gap:12px;
+  list-style:none;
+}
+.media-grid li{
+  background:#fff;border:1px solid #e2ddd1;border-radius:10px;padding:16px 18px;
+  font-family:var(--serif);font-weight:600;font-size:1.02rem;color:var(--paper-ink);
+  display:flex;align-items:center;justify-content:center;text-align:center;min-height:64px;
+}
+
+/* ============================================================
+   TEAM
+   ============================================================ */
+.team-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-top:34px}
+.team-card{
+  background:var(--ink-2);border:1px solid var(--hair);border-radius:14px;padding:24px 22px 22px;
+}
+.team-card .avatar{
+  width:52px;height:52px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+  font-family:var(--data);font-weight:700;font-size:1.05rem;color:var(--ink);margin-bottom:16px;
+}
+.team-card h3{font-family:var(--serif);font-size:1.18rem;font-weight:600;line-height:1.25}
+.team-card .role{font-family:var(--data);font-size:.72rem;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);margin-top:5px}
+.team-card .email{display:inline-block;margin-top:14px;font-family:var(--data);font-size:.78rem;color:var(--text-2);text-decoration:none;word-break:break-all}
+.team-card .email:hover{color:var(--text)}
+
+/* ============================================================
+   WHERE WE WORK
+   ============================================================ */
+.countries-grid{display:grid;grid-template-columns:repeat(5,1fr);gap:14px;margin-top:34px}
+.country-card{background:#fff;border:1px solid #e2ddd1;border-radius:12px;padding:20px 20px 18px}
+.country-card .flag{font-size:1.4rem;line-height:1;margin-bottom:12px}
+.country-card h3{font-family:var(--serif);font-size:1.15rem;font-weight:640;color:var(--paper-ink)}
+.country-card .count{font-family:var(--data);font-size:.68rem;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:#8a8375;margin:3px 0 12px}
+.country-card ul{list-style:none;display:flex;flex-wrap:wrap;gap:6px}
+.country-card li{
+  font-family:var(--data);font-size:.76rem;color:#4d473c;background:var(--paper);
+  border:1px solid #e2ddd1;border-radius:999px;padding:3px 11px;white-space:nowrap;
+}
+.where-total{margin-top:26px;font-family:var(--data);font-size:.82rem;color:#6d675c}
+.where-total strong{color:var(--paper-ink)}
+
+/* ============================================================
+   CTA
+   ============================================================ */
+.cta-section{position:relative;overflow:hidden;border-top:1px solid var(--hair)}
+.cta-section::before{
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:radial-gradient(50rem 26rem at 50% 120%, rgba(70,209,127,.1), transparent 65%);
+}
+.cta-inner{position:relative;text-align:center;padding:96px 24px;max-width:760px;margin:0 auto}
+.cta-inner h2{
+  font-family:var(--serif);font-weight:640;font-size:clamp(2rem,4.4vw,3.3rem);
+  line-height:1.08;letter-spacing:-.015em;
+}
+.cta-inner p{margin:20px auto 32px;color:var(--text-2);max-width:46ch}
+.cta-inner .aqi-spine{width:120px;margin:0 auto 28px}
+
+/* ============================================================
+   FOOTER
+   ============================================================ */
+.site-footer{background:#080a10;border-top:1px solid var(--hair);padding:64px 0 40px}
+.footer-grid{display:grid;grid-template-columns:1.4fr 1fr 1fr 1fr;gap:40px}
+.footer-mission{font-size:.9rem;color:var(--text-2);margin-top:14px;max-width:38ch}
+.footer-col h4{
+  font-family:var(--data);font-size:.66rem;font-weight:700;letter-spacing:.16em;
+  text-transform:uppercase;color:var(--muted);margin-bottom:16px;
+}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:9px}
+.footer-col a{font-size:.88rem;color:var(--text-2);text-decoration:none}
+.footer-col a:hover{color:var(--text)}
+.footer-bottom{
+  margin-top:52px;padding-top:22px;border-top:1px solid var(--hair);
+  display:flex;justify-content:space-between;gap:14px;flex-wrap:wrap;
+  font-family:var(--data);font-size:.74rem;color:var(--muted);
+}
+.footer-bottom a{color:var(--text-2)}
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width:1020px){
+  .story-cols{grid-template-columns:1fr;gap:36px}
+  .projects-grid{grid-template-columns:1fr}
+  .backers-grid{grid-template-columns:1fr}
+  .media-grid{grid-template-columns:1fr 1fr}
+  .team-grid{grid-template-columns:1fr 1fr}
+  .countries-grid{grid-template-columns:1fr 1fr}
+  .footer-grid{grid-template-columns:1fr 1fr}
+}
+@media (max-width:820px){
+  .main-nav{display:none}
+  .about-hero .hero-inner{padding:64px 0 56px}
+}
+@media (max-width:600px){
+  .media-grid,.team-grid,.countries-grid,.footer-grid{grid-template-columns:1fr}
+  .section{padding:60px 0}
+}
+
+/* ============================================================
+   REDUCED MOTION
+   ============================================================ */
+@media (prefers-reduced-motion:reduce){
+  html{scroll-behavior:auto}
+  .project-card,.backer-card{transition:none}
+  .project-card:hover,.backer-card:hover{transform:none}
+}
+</style>
+</head>
+<body>
+
+<!-- ============================================================
+     HEADER
+     ============================================================ -->
+<header class="site-header">
+  <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+  <div class="header-inner">
+    <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+    <nav class="main-nav" aria-label="Primary">
+      <a class="live-link" href="air.html">Air</a>
+      <a href="water.html">Water</a>
+      <a href="sound.html">Sound</a>
+      <a href="radiation.html">Radiation</a>
+      <a href="data.html">Data</a>
+      <a href="stories.html">Stories</a>
+      <a href="about.html" aria-current="page">About</a>
+    </nav>
+    <a class="nav-cta" href="get-started.html">Get a sensor</a>
+  </div>
+</header>
+
+<main>
+
+<!-- ============================================================
+     EDITORIAL HERO
+     ============================================================ -->
+<section class="about-hero">
+  <div class="wrap hero-inner">
+    <p class="kicker">Who we are</p>
+    <h1>About sensors<span class="dot-africa">.AFRICA</span></h1>
+    <p class="mission">
+      sensors.AFRICA is a pan-African citizen science initiative that uses sensors to monitor
+      air, water and sound pollution to give citizens actionable information about their cities.
+    </p>
+    <span class="proto-badge">Prototype &middot; redesign concept</span>
+  </div>
+</section>
+
+<!-- ============================================================
+     LONG-FORM STORY — warm paper reading surface
+     ============================================================ -->
+<section class="section paper-section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <p class="kicker">Our story</p>
+    <h2 class="display">Citizen science, built for the data gaps</h2>
+    <div class="story-cols">
+      <div class="story-prose">
+        <p>
+          sensors.AFRICA is a citizen-science project by <strong>Code for Africa</strong> that
+          addresses the data gaps across the continent by providing low-cost sensors that people
+          use to measure and monitor the air, water and sound quality of their own communities.
+        </p>
+        <p>
+          Our air quality sensors are built on <strong>open-source technology from the Luftdaten
+          project</strong> — hardware cheap enough for a household to host, and open enough for
+          anyone to inspect. The initiative was <strong>seed-funded by innovateAFRICA</strong> and
+          is <strong>incubated by Code for Africa</strong>.
+        </p>
+        <p>
+          Citizens and governments alike are increasingly aware of the toxic health risks of air
+          pollution — but what they lack is accessible, hyper-local, real-time data about the air
+          on their own streets. <strong>sensors.AFRICA changes this.</strong> Data from our
+          low-cost sensor network is already being used by <strong>watchdog NGOs and
+          journalists</strong> to spotlight public-health risks: live readings for what is
+          happening right now, and historical archives for the patterns that only emerge over
+          months and years.
+        </p>
+      </div>
+      <div class="story-aside" aria-label="Key facts about sensors.AFRICA">
+        <div class="fact-card">
+          <div class="fk">Incubated by</div>
+          <div class="fv"><a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a></div>
+          <div class="fs">The continent's largest network of civic technology and data journalism labs.</div>
+          <div class="fbar" style="background:var(--aqi-good)" aria-hidden="true"></div>
+        </div>
+        <div class="fact-card">
+          <div class="fk">Seed-funded by</div>
+          <div class="fv"><a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a></div>
+          <div class="fs">Backing digital innovation experiments in African news and civic media.</div>
+          <div class="fbar" style="background:var(--aqi-moderate)" aria-hidden="true"></div>
+        </div>
+        <div class="fact-card">
+          <div class="fk">Powered by</div>
+          <div class="fv"><a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></div>
+          <div class="fs">Open-source sensor technology from the global Luftdaten community.</div>
+          <div class="fbar" style="background:var(--aqi-sensitive)" aria-hidden="true"></div>
+        </div>
+      </div>
+    </div>
+    <p class="paper-credit">Live sensor data and historical archives are published openly for journalists, researchers and residents.</p>
+  </div>
+</section>
+
+<!-- ============================================================
+     PROJECTS UNDER sensors.AFRICA
+     ============================================================ -->
+<section class="section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">What we run</p>
+        <h2 class="display">Projects under sensors.AFRICA</h2>
+      </div>
+      <p class="lede">One network, three fronts: the air above the city, the water it drinks, and the storms on its largest lake.</p>
+    </div>
+    <div class="projects-grid">
+      <a class="project-card" href="air.html">
+        <span class="accent" style="background:var(--aqi-sensitive)" aria-hidden="true"></span>
+        <p class="p-tag">Air</p>
+        <h3>sensors.AFRICA AIR</h3>
+        <p>Live air-quality monitoring with low-cost sensors measuring PM<sub>2.5</sub> and PM<sub>10</sub> particulates — hyper-local readings published in real time, city by city.</p>
+        <div class="p-foot"><span class="p-stat" style="color:var(--aqi-good);border-color:rgba(70,209,127,.4)">Live network</span><span>PM2.5 &middot; PM10</span></div>
+      </a>
+      <a class="project-card" href="water.html">
+        <span class="accent" style="background:#4fa8d8" aria-hidden="true"></span>
+        <p class="p-tag">Water</p>
+        <h3>sensors.AFRICA WATER</h3>
+        <p>Monitoring drinking-water contamination — sensor-driven evidence about the safety of the water communities rely on every day.</p>
+        <div class="p-foot"><span class="p-stat">Water quality</span><span>Contamination monitoring</span></div>
+      </a>
+      <a class="project-card" href="stories.html">
+        <span class="accent" style="background:var(--aqi-veryunhealthy)" aria-hidden="true"></span>
+        <p class="p-tag">StormWatch</p>
+        <h3>StormWatch &middot; VIEWS</h3>
+        <p>A storm early-warning system for Lake Victoria — "VIEWS" — giving fishing communities advance notice of dangerous weather on the lake.</p>
+        <div class="p-foot"><span class="p-stat" style="color:var(--aqi-moderate);border-color:rgba(244,197,66,.4)">~93% accuracy</span><span>Reported prediction accuracy</span></div>
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     PARTNERS & MEDIA PARTNERS — paper surface
+     ============================================================ -->
+<section class="section paper-section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">Partners</p>
+        <h2 class="display">Built with partners, amplified by newsrooms</h2>
+      </div>
+      <p class="lede">The institutions that incubate, fund and power the network — and the media partners who turn its data into public-interest journalism.</p>
+    </div>
+
+    <div class="backers-grid">
+      <a class="backer-card" href="https://codeforafrica.org/" rel="noopener">
+        <div class="bk">Incubated by</div>
+        <div class="bn">Code for Africa</div>
+        <div class="bs">sensors.AFRICA is a citizen-science project incubated within Code for Africa.</div>
+      </a>
+      <a class="backer-card" href="https://innovateafrica.fund/" rel="noopener">
+        <div class="bk">Seed-funded by</div>
+        <div class="bn">innovateAFRICA</div>
+        <div class="bs">Seed funding from the innovateAFRICA fund launched the sensor network.</div>
+      </a>
+      <a class="backer-card" href="https://luftdaten.info/" rel="noopener">
+        <div class="bk">Powered by</div>
+        <div class="bn">Luftdaten</div>
+        <div class="bs">Our air-quality sensors use open-source technology from the Luftdaten project.</div>
+      </a>
+    </div>
+
+    <p class="media-title">Media partners</p>
+    <ul class="media-grid" aria-label="Media partners">
+      <li>Business Daily</li>
+      <li>Premium Times</li>
+      <li>The Guardian</li>
+      <li>The Nation</li>
+      <li>The Star</li>
+      <li>Woman NG</li>
+      <li>Daily Nation</li>
+      <li>The Cable</li>
+    </ul>
+  </div>
+</section>
+
+<!-- ============================================================
+     CONTRIBUTORS & STAFF
+     ============================================================ -->
+<section class="section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">The people</p>
+        <h2 class="display">Contributors &amp; staff</h2>
+      </div>
+      <p class="lede">The team building and running the network — reach any of us directly.</p>
+    </div>
+    <div class="team-grid">
+      <div class="team-card">
+        <div class="avatar" style="background:var(--aqi-good)" aria-hidden="true">AO</div>
+        <h3>Alicia Olago</h3>
+        <p class="role">sensors.AFRICA team</p>
+        <a class="email" href="mailto:alicia.olago@codeforafrica.org">alicia.olago@codeforafrica.org</a>
+      </div>
+      <div class="team-card">
+        <div class="avatar" style="background:var(--aqi-moderate)" aria-hidden="true">AM</div>
+        <h3>Augustine Mwendwa</h3>
+        <p class="role">sensors.AFRICA team</p>
+        <a class="email" href="mailto:mwendwa.mutinda@codeforafrica.org">mwendwa.mutinda@codeforafrica.org</a>
+      </div>
+      <div class="team-card">
+        <div class="avatar" style="background:var(--aqi-sensitive)" aria-hidden="true">GM</div>
+        <h3>Gideon Maina</h3>
+        <p class="role">sensors.AFRICA team</p>
+        <a class="email" href="mailto:gideon@codeforafrica.org">gideon@codeforafrica.org</a>
+      </div>
+      <div class="team-card">
+        <div class="avatar" style="background:var(--aqi-veryunhealthy)" aria-hidden="true">AU</div>
+        <h3>Ahmed Biu Usman</h3>
+        <p class="role">sensors.AFRICA team</p>
+        <a class="email" href="mailto:usman@codeforafrica.org">usman@codeforafrica.org</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     WHERE WE WORK — paper surface
+     ============================================================ -->
+<section class="section paper-section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">Where we work</p>
+        <h2 class="display">Sixteen cities, five countries</h2>
+      </div>
+      <p class="lede">From Nairobi's estates to Lagos mainland, sensors hosted by citizens are putting African cities on the pollution map.</p>
+    </div>
+    <div class="countries-grid">
+      <div class="country-card">
+        <div class="flag" aria-hidden="true">🇰🇪</div>
+        <h3>Kenya</h3>
+        <p class="count">3 cities</p>
+        <ul>
+          <li>Nairobi</li>
+          <li>Nakuru</li>
+          <li>Kisumu</li>
+        </ul>
+      </div>
+      <div class="country-card">
+        <div class="flag" aria-hidden="true">🇹🇿</div>
+        <h3>Tanzania</h3>
+        <p class="count">1 city</p>
+        <ul>
+          <li>Dar es Salaam</li>
+        </ul>
+      </div>
+      <div class="country-card">
+        <div class="flag" aria-hidden="true">🇳🇬</div>
+        <h3>Nigeria</h3>
+        <p class="count">9 cities</p>
+        <ul>
+          <li>Lagos</li>
+          <li>Abuja</li>
+          <li>Ilorin</li>
+          <li>Maiduguri</li>
+          <li>Port Harcourt</li>
+          <li>Kano</li>
+          <li>Awka</li>
+          <li>Akure</li>
+          <li>Ado-Ekiti</li>
+        </ul>
+      </div>
+      <div class="country-card">
+        <div class="flag" aria-hidden="true">🇬🇭</div>
+        <h3>Ghana</h3>
+        <p class="count">2 cities</p>
+        <ul>
+          <li>Accra</li>
+          <li>Kumasi</li>
+        </ul>
+      </div>
+      <div class="country-card">
+        <div class="flag" aria-hidden="true">🇿🇲</div>
+        <h3>Zambia</h3>
+        <p class="count">1 city</p>
+        <ul>
+          <li>Lusaka</li>
+        </ul>
+      </div>
+    </div>
+    <p class="where-total"><strong>16 cities</strong> across <strong>5 countries</strong> — and every new sensor host extends the map.</p>
+  </div>
+</section>
+
+<!-- ============================================================
+     CTA
+     ============================================================ -->
+<section class="cta-section">
+  <div class="cta-inner">
+    <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <h2>Be the sensor your street is missing.</h2>
+    <p>Host a low-cost sensor at your home, school or office and add your neighbourhood to the public record.</p>
+    <a class="btn btn-primary" href="get-started.html">Get started — join the network</a>
+    <div><span class="proto-badge">Prototype &middot; redesign concept</span></div>
+  </div>
+</section>
+
+</main>
+
+<!-- ============================================================
+     FOOTER
+     ============================================================ -->
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+        <p class="footer-mission">A pan-African citizen science initiative using sensors to monitor air, water and sound pollution — giving citizens actionable information about their cities.</p>
+      </div>
+      <div class="footer-col">
+        <h4>Network</h4>
+        <ul>
+          <li><a href="air.html">Air quality</a></li>
+          <li><a href="water.html">Water</a></li>
+          <li><a href="sound.html">Sound</a></li>
+          <li><a href="radiation.html">Radiation</a></li>
+          <li><a href="data.html">Open data</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Community</h4>
+        <ul>
+          <li><a href="stories.html">Stories</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="get-started.html">Get a sensor</a></li>
+          <li><a href="https://twitter.com/sensorsAFRICA/" rel="noopener">Twitter</a></li>
+          <li><a href="https://www.instagram.com/sensorsAFRICA/" rel="noopener">Instagram</a></li>
+          <li><a href="https://medium.com/@sensors.AFRICA" rel="noopener">Medium</a></li>
+          <li><a href="https://github.com/CodeForAfrica/sensors.AFRICA" rel="noopener">GitHub</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Partners</h4>
+        <ul>
+          <li><a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a></li>
+          <li><a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a></li>
+          <li><a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>Incubated by <a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a> · seed-funded by <a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a> · powered by <a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></span>
+      <span>Redesign prototype — all readings on this page are illustrative sample data.</span>
+    </div>
+  </div>
+</footer>
+
+<!-- ============================================================
+     SCRIPT — cosmetic only; page is fully functional without JS
+     ============================================================ -->
+<script>
+try {
+  // Defensive nav highlight: keep About marked active even if markup is reused.
+  var links = document.querySelectorAll('.main-nav a');
+  for (var i = 0; i < links.length; i++) {
+    var href = links[i].getAttribute('href') || '';
+    if (href.indexOf('about.html') !== -1) links[i].setAttribute('aria-current', 'page');
+  }
+} catch (err) {
+  console.warn('Nav highlight skipped:', err && err.message);
+}
+</script>
+
+</body>
+</html>

--- a/redesign/air.html
+++ b/redesign/air.html
@@ -1,0 +1,1303 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Air — sensors.AFRICA · Live PM2.5 air quality for African cities</title>
+<meta name="description" content="Live, citizen-collected PM2.5 and PM10 air quality readings across 16 African cities — hour-by-hour trends, city comparisons, health guidance and open data from the sensors.AFRICA network.">
+
+<!-- Fonts: Fraunces (display serif) · Space Grotesk (data) · Inter (body) -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Space+Grotesk:wght@400;500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+
+<!-- Leaflet (map) -->
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="">
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
+
+<style>
+/* ============================================================
+   TOKENS — shared with all subpages, do not diverge
+   ============================================================ */
+:root{
+  --ink:#0c0f16; --ink-2:#141821; --ink-3:#1a1f2b;
+  --paper:#f1eee7; --paper-ink:#17140f;
+  --text:#e9ebf0; --text-2:#9aa2b1; --muted:#6b7280;
+  --hair:rgba(255,255,255,0.09); --hair-strong:rgba(255,255,255,0.16);
+  --aqi-good:#46d17f; --aqi-moderate:#f4c542; --aqi-sensitive:#f5822e;
+  --aqi-unhealthy:#ef5350; --aqi-veryunhealthy:#b06ae0; --aqi-hazardous:#c0466c;
+  --serif:"Fraunces",Georgia,serif;
+  --sans:"Inter",system-ui,-apple-system,sans-serif;
+  --data:"Space Grotesk","Inter",system-ui,sans-serif;
+  --maxw:1200px;
+}
+
+/* ============================================================
+   BASE
+   ============================================================ */
+*{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  background:var(--ink); color:var(--text);
+  font-family:var(--sans); font-size:16px; line-height:1.6;
+  -webkit-font-smoothing:antialiased;
+}
+img{max-width:100%;display:block}
+a{color:inherit}
+:focus-visible{outline:2px solid var(--aqi-moderate);outline-offset:3px;border-radius:2px}
+::selection{background:var(--aqi-sensitive);color:var(--ink)}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
+.kicker{
+  font-family:var(--data);font-size:.75rem;font-weight:500;
+  letter-spacing:.18em;text-transform:uppercase;color:var(--text-2);
+}
+.section-head{display:flex;align-items:baseline;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-bottom:8px}
+h2.display{
+  font-family:var(--serif);font-weight:600;font-size:clamp(1.7rem,3.4vw,2.6rem);
+  line-height:1.12;letter-spacing:-.01em;margin:10px 0 14px;
+}
+.lede{color:var(--text-2);max-width:56ch}
+.section{padding:84px 0}
+
+/* The AQI spine — a segmented band used as the page's structural accent */
+.aqi-spine{display:flex;height:4px;width:100%}
+.aqi-spine span{flex:1}
+.aqi-spine .s1{background:var(--aqi-good)}
+.aqi-spine .s2{background:var(--aqi-moderate)}
+.aqi-spine .s3{background:var(--aqi-sensitive)}
+.aqi-spine .s4{background:var(--aqi-unhealthy)}
+.aqi-spine .s5{background:var(--aqi-veryunhealthy)}
+.aqi-spine .s6{background:var(--aqi-hazardous)}
+.spine-sm{width:64px;height:4px;margin-bottom:14px}
+
+/* ============================================================
+   HEADER
+   ============================================================ */
+.site-header{
+  position:sticky;top:0;z-index:1000;
+  background:rgba(12,15,22,.88);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+  border-bottom:1px solid var(--hair);
+}
+.header-inner{
+  max-width:var(--maxw);margin:0 auto;padding:0 24px;
+  display:flex;align-items:center;justify-content:space-between;gap:20px;height:64px;
+}
+.wordmark{
+  font-family:var(--data);font-weight:700;font-size:1.05rem;letter-spacing:.01em;
+  text-decoration:none;white-space:nowrap;
+}
+.wordmark .dot-africa{color:var(--aqi-good)}
+.main-nav{display:flex;gap:2px;align-items:center;overflow-x:auto}
+.main-nav a{
+  font-family:var(--data);font-size:.82rem;font-weight:500;color:var(--text-2);
+  text-decoration:none;padding:8px 11px;border-radius:6px;white-space:nowrap;
+}
+.main-nav a:hover{color:var(--text);background:var(--ink-3)}
+.main-nav a.live-link{color:var(--text)}
+.main-nav a.live-link::before{
+  content:"";display:inline-block;width:6px;height:6px;border-radius:50%;
+  background:var(--aqi-good);margin-right:7px;vertical-align:1px;
+}
+.main-nav a[aria-current="page"]{color:var(--text);background:var(--ink-3)}
+.nav-cta{
+  font-family:var(--data);font-size:.82rem;font-weight:700;text-decoration:none;
+  color:var(--ink);background:var(--aqi-good);padding:9px 16px;border-radius:999px;white-space:nowrap;
+}
+.nav-cta:hover{background:#5fdd92}
+
+/* ============================================================
+   HERO
+   ============================================================ */
+.hero{position:relative;overflow:hidden;border-bottom:1px solid var(--hair)}
+.hero::before{ /* faint atmospheric wash */
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:
+    radial-gradient(52rem 30rem at 78% -10%, rgba(245,130,46,.11), transparent 60%),
+    radial-gradient(44rem 26rem at 8% 110%, rgba(70,209,127,.06), transparent 60%);
+}
+.hero-grid{
+  position:relative;display:grid;grid-template-columns:minmax(0,1.15fr) minmax(0,.85fr);
+  gap:56px;align-items:center;padding:76px 0 68px;
+}
+.hero h1{
+  font-family:var(--serif);font-weight:640;font-variation-settings:"opsz" 100;
+  font-size:clamp(2.5rem,5.4vw,4.3rem);line-height:1.04;letter-spacing:-.015em;
+}
+.hero h1 em{font-style:italic;font-weight:520;color:var(--aqi-sensitive)}
+.hero .standfirst{margin-top:22px;font-size:1.08rem;color:var(--text-2);max-width:52ch}
+.hero-actions{margin-top:30px;display:flex;gap:14px;flex-wrap:wrap;align-items:center}
+.btn{
+  font-family:var(--data);font-weight:700;font-size:.92rem;text-decoration:none;
+  padding:13px 24px;border-radius:999px;display:inline-block;
+}
+.btn-primary{background:var(--aqi-good);color:var(--ink)}
+.btn-primary:hover{background:#5fdd92}
+.btn-ghost{color:var(--text);border:1px solid var(--hair-strong)}
+.btn-ghost:hover{border-color:var(--text-2)}
+.proto-badge{
+  display:inline-flex;align-items:center;gap:7px;margin-top:26px;
+  font-family:var(--data);font-size:.68rem;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--muted);border:1px solid var(--hair);border-radius:999px;padding:5px 12px;
+}
+.proto-badge::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--aqi-moderate)}
+
+/* Live reading panel — the hero centerpiece */
+.reading-panel{
+  position:relative;background:var(--ink-2);border:1px solid var(--hair-strong);
+  border-radius:16px;padding:26px 28px 24px;box-shadow:0 24px 60px rgba(0,0,0,.45);
+}
+.reading-panel .panel-spine{position:absolute;top:0;left:0;right:0;border-radius:16px 16px 0 0;overflow:hidden}
+.panel-top{display:flex;justify-content:space-between;align-items:baseline;gap:12px;margin-top:6px}
+.panel-city{font-family:var(--serif);font-size:1.5rem;font-weight:600}
+.panel-live{
+  font-family:var(--data);font-size:.68rem;letter-spacing:.16em;text-transform:uppercase;color:var(--text-2);
+  display:inline-flex;align-items:center;gap:7px;
+}
+.panel-live .pulse{width:8px;height:8px;border-radius:50%;background:var(--aqi-good);animation:pulse 2.2s ease-out infinite}
+@keyframes pulse{0%{box-shadow:0 0 0 0 rgba(70,209,127,.55)}70%{box-shadow:0 0 0 9px rgba(70,209,127,0)}100%{box-shadow:0 0 0 0 rgba(70,209,127,0)}}
+.big-reading{display:flex;align-items:baseline;gap:12px;margin:14px 0 4px}
+.big-reading .num{
+  font-family:var(--data);font-weight:700;font-size:clamp(4rem,7vw,5.6rem);
+  line-height:1;letter-spacing:-.02em;color:var(--aqi-sensitive);
+}
+.big-reading .unit-block{font-family:var(--data);color:var(--text-2);font-size:.85rem;line-height:1.4}
+.band-chip{
+  display:inline-flex;align-items:center;gap:8px;margin-top:8px;
+  font-family:var(--data);font-size:.8rem;font-weight:500;color:var(--text);
+  background:var(--ink-3);border:1px solid var(--hair);border-radius:999px;padding:6px 14px;
+}
+.band-chip .swatch{width:9px;height:9px;border-radius:50%;background:var(--aqi-sensitive)}
+/* mini AQI meter: reading position on the health scale */
+.aqi-meter{margin-top:22px}
+.aqi-meter .track{position:relative;height:6px;border-radius:3px;overflow:visible;display:flex}
+.aqi-meter .track span{flex:1;opacity:.85}
+.aqi-meter .track span:first-child{border-radius:3px 0 0 3px}
+.aqi-meter .track span:last-child{border-radius:0 3px 3px 0}
+.aqi-meter .needle{
+  position:absolute;top:-4px;width:3px;height:14px;border-radius:2px;
+  background:var(--text);box-shadow:0 0 0 2px var(--ink-2);left:44%;
+}
+.aqi-meter .scale-labels{
+  display:flex;justify-content:space-between;margin-top:8px;
+  font-family:var(--data);font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);
+}
+.panel-meta{
+  margin-top:20px;padding-top:14px;border-top:1px solid var(--hair);
+  display:flex;justify-content:space-between;gap:10px;flex-wrap:wrap;
+  font-family:var(--data);font-size:.72rem;color:var(--muted);
+}
+.panel-meta strong{color:var(--text-2);font-weight:500}
+
+/* ============================================================
+   CITY SELECTOR (dashboard)
+   ============================================================ */
+.city-tabs{display:flex;flex-wrap:wrap;gap:8px;margin-top:28px}
+.city-tabs button{
+  font-family:var(--data);font-size:.84rem;font-weight:500;color:var(--text-2);
+  background:var(--ink-2);border:1px solid var(--hair);border-radius:999px;
+  padding:9px 17px;cursor:pointer;display:inline-flex;align-items:center;gap:9px;
+  transition:border-color .15s ease,color .15s ease;
+}
+.city-tabs button:hover{color:var(--text);border-color:var(--hair-strong)}
+.city-tabs button[aria-pressed="true"]{color:var(--ink);background:var(--text);border-color:var(--text);font-weight:700}
+.city-tabs .dot{width:8px;height:8px;border-radius:50%;flex:none}
+.tabs-note{margin-top:12px;font-family:var(--data);font-size:.74rem;color:var(--muted)}
+
+/* ============================================================
+   CHART CARDS
+   ============================================================ */
+.chart-card{
+  margin-top:34px;background:var(--ink-2);border:1px solid var(--hair);
+  border-radius:16px;padding:26px 22px 16px;position:relative;
+}
+.chart-card .chart-title-row{display:flex;justify-content:space-between;align-items:baseline;flex-wrap:wrap;gap:8px;padding:0 8px}
+.chart-card h3{font-family:var(--serif);font-size:1.2rem;font-weight:600}
+.chart-card .sub{font-family:var(--data);font-size:.74rem;color:var(--muted)}
+.trend-svg{width:100%;height:auto;display:block;margin-top:10px}
+.trend-svg text{font-family:var(--data)}
+.chart-tip{
+  position:absolute;pointer-events:none;display:none;z-index:5;
+  background:var(--ink);border:1px solid var(--hair-strong);border-radius:8px;
+  padding:7px 11px;font-family:var(--data);font-size:.75rem;white-space:nowrap;
+  transform:translate(-50%,-130%);box-shadow:0 8px 24px rgba(0,0,0,.5);
+}
+.chart-table{margin:6px 8px 10px}
+.chart-table summary{font-family:var(--data);font-size:.74rem;color:var(--muted);cursor:pointer}
+.chart-table summary:hover{color:var(--text-2)}
+.chart-table table{margin-top:12px;border-collapse:collapse;font-family:var(--data);font-size:.74rem;width:100%}
+.chart-table th,.chart-table td{
+  border:1px solid var(--hair);padding:4px 8px;text-align:right;
+  font-variant-numeric:tabular-nums;color:var(--text-2);
+}
+.chart-table th{color:var(--muted);font-weight:500}
+.data-note{margin-top:14px;font-size:.75rem;color:var(--muted);font-family:var(--data)}
+.bar-legend{
+  display:flex;flex-wrap:wrap;gap:6px 18px;padding:12px 8px 0;
+  font-family:var(--data);font-size:.72rem;color:var(--text-2);
+}
+.bar-legend li{list-style:none;display:flex;align-items:center;gap:7px;white-space:nowrap}
+.bar-legend .sw{width:9px;height:9px;border-radius:50%;flex:none}
+
+/* ============================================================
+   MAP
+   ============================================================ */
+.map-section{background:var(--ink-2);border-top:1px solid var(--hair);border-bottom:1px solid var(--hair)}
+.map-shell{
+  position:relative;margin-top:34px;border:1px solid var(--hair-strong);
+  border-radius:16px;overflow:hidden;height:540px;
+  /* graceful fallback: atmospheric gradient + faint graticule if tiles never load */
+  background:
+    linear-gradient(var(--hair) 1px,transparent 1px),
+    linear-gradient(90deg,var(--hair) 1px,transparent 1px),
+    radial-gradient(60rem 34rem at 50% 20%,#151a26,var(--ink));
+  background-size:64px 64px,64px 64px,cover;
+}
+#africa-map{position:absolute;inset:0;background:transparent}
+.leaflet-container{background:transparent;font-family:var(--sans)}
+.map-fallback-note{
+  position:absolute;inset:0;display:flex;align-items:center;justify-content:center;
+  color:var(--muted);font-family:var(--data);font-size:.85rem;text-align:center;padding:24px;
+}
+.map-legend{
+  position:absolute;z-index:800;left:16px;bottom:16px;
+  background:rgba(12,15,22,.9);border:1px solid var(--hair-strong);border-radius:12px;
+  padding:14px 16px;font-family:var(--data);font-size:.72rem;color:var(--text-2);
+  backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);
+}
+.map-legend .lg-title{font-weight:700;letter-spacing:.12em;text-transform:uppercase;font-size:.62rem;color:var(--muted);margin-bottom:9px}
+.map-legend ul{list-style:none;display:grid;grid-template-columns:1fr 1fr;gap:5px 18px}
+.map-legend li{display:flex;align-items:center;gap:8px;white-space:nowrap}
+.map-legend .sw{width:9px;height:9px;border-radius:50%;flex:none}
+.map-count{
+  position:absolute;z-index:800;right:16px;top:16px;text-align:right;
+  background:rgba(12,15,22,.9);border:1px solid var(--hair-strong);border-radius:12px;padding:12px 16px;
+  font-family:var(--data);backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);
+}
+.map-count .n{font-size:1.5rem;font-weight:700;line-height:1.1}
+.map-count .l{font-size:.64rem;letter-spacing:.12em;text-transform:uppercase;color:var(--muted)}
+.leaflet-popup-content-wrapper{background:var(--ink-3);color:var(--text);border-radius:10px;border:1px solid var(--hair-strong)}
+.leaflet-popup-tip{background:var(--ink-3)}
+.leaflet-popup-content{font-family:var(--data);font-size:.85rem;margin:12px 16px}
+.popup-city{font-weight:700;font-size:1rem}
+.popup-reading{font-variant-numeric:tabular-nums}
+
+/* ============================================================
+   HEALTH GUIDANCE — the six bands
+   ============================================================ */
+.band-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-top:34px}
+.band-card{
+  position:relative;background:var(--ink-2);border:1px solid var(--hair);
+  border-radius:14px;padding:26px 24px 22px;overflow:hidden;
+}
+.band-card .accent{position:absolute;top:0;left:0;right:0;height:3px}
+.band-head{display:flex;justify-content:space-between;align-items:baseline;gap:10px;flex-wrap:wrap}
+.band-card h3{font-family:var(--serif);font-size:1.22rem;font-weight:600;display:flex;align-items:center;gap:10px}
+.band-card h3 .sw{width:10px;height:10px;border-radius:50%;flex:none}
+.band-range{font-family:var(--data);font-size:.72rem;color:var(--muted);white-space:nowrap;font-variant-numeric:tabular-nums}
+.band-card .meaning{font-size:.88rem;color:var(--text-2);margin-top:10px;min-height:3.2em}
+.band-card .advice{margin-top:14px;padding-top:13px;border-top:1px solid var(--hair);font-size:.84rem;color:var(--text-2)}
+.band-card .advice strong{
+  color:var(--text);font-weight:700;font-family:var(--data);font-size:.64rem;
+  letter-spacing:.16em;text-transform:uppercase;display:block;margin-bottom:5px;
+}
+
+/* ============================================================
+   PAPER SECTION — why it matters (long-form reading surface)
+   ============================================================ */
+.paper-section{background:var(--paper);color:var(--paper-ink)}
+.paper-section .kicker{color:#6d675c}
+.paper-section h2.display{color:var(--paper-ink)}
+.paper-section .lede{color:#4d473c}
+.impact-grid{display:grid;grid-template-columns:1.1fr .9fr;gap:56px;align-items:start;margin-top:20px}
+.impact-prose{font-family:var(--serif);font-size:1.16rem;line-height:1.72;color:#2c2820;font-weight:420}
+.impact-prose p+p{margin-top:1.1em}
+.impact-prose strong{font-weight:640;color:var(--paper-ink)}
+.stat-tiles{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+.stat-tile{background:#fff;border:1px solid #e2ddd1;border-radius:12px;padding:20px 20px 18px}
+.stat-tile .val{font-family:var(--data);font-weight:700;font-size:2.1rem;line-height:1.1;color:var(--paper-ink)}
+.stat-tile .lbl{font-size:.8rem;color:#6d675c;margin-top:6px;line-height:1.45}
+.stat-tile .bar{height:4px;border-radius:2px;background:#ece8dd;margin-top:14px;overflow:hidden}
+.stat-tile .bar i{display:block;height:100%;border-radius:2px}
+.paper-credit{margin-top:34px;font-family:var(--data);font-size:.74rem;color:#8a8375}
+
+/* ============================================================
+   HOW THE SENSORS WORK
+   ============================================================ */
+.sensor-grid{display:grid;grid-template-columns:1.05fr .95fr;gap:52px;align-items:start;margin-top:30px}
+.sensor-prose p{color:var(--text-2)}
+.sensor-prose p+p{margin-top:1em}
+.sensor-prose strong{color:var(--text);font-weight:600}
+.spec-card{background:var(--ink-2);border:1px solid var(--hair);border-radius:14px;padding:26px 26px 20px}
+.spec-card h3{font-family:var(--serif);font-size:1.2rem;font-weight:600;margin-bottom:16px}
+.spec-card dl{font-family:var(--data);font-size:.85rem}
+.spec-card .spec-row{
+  display:flex;justify-content:space-between;gap:18px;
+  padding:10px 0;border-top:1px solid var(--hair);
+}
+.spec-card dt{color:var(--muted);font-size:.72rem;letter-spacing:.12em;text-transform:uppercase;padding-top:2px;white-space:nowrap}
+.spec-card dd{color:var(--text);text-align:right}
+
+/* ============================================================
+   CTA
+   ============================================================ */
+.cta-section{position:relative;overflow:hidden;border-top:1px solid var(--hair)}
+.cta-section::before{
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:radial-gradient(50rem 26rem at 50% 120%, rgba(70,209,127,.1), transparent 65%);
+}
+.cta-inner{position:relative;text-align:center;padding:96px 24px;max-width:760px;margin:0 auto}
+.cta-inner h2{
+  font-family:var(--serif);font-weight:640;font-size:clamp(2rem,4.4vw,3.3rem);
+  line-height:1.08;letter-spacing:-.015em;
+}
+.cta-inner p{margin:20px auto 32px;color:var(--text-2);max-width:46ch}
+.cta-inner .aqi-spine{width:120px;margin:0 auto 28px}
+
+/* ============================================================
+   FOOTER
+   ============================================================ */
+.site-footer{background:#080a10;border-top:1px solid var(--hair);padding:64px 0 40px}
+.footer-grid{display:grid;grid-template-columns:1.4fr 1fr 1fr 1fr;gap:40px}
+.footer-mission{font-size:.9rem;color:var(--text-2);margin-top:14px;max-width:38ch}
+.footer-col h4{
+  font-family:var(--data);font-size:.66rem;font-weight:700;letter-spacing:.16em;
+  text-transform:uppercase;color:var(--muted);margin-bottom:16px;
+}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:9px}
+.footer-col a{font-size:.88rem;color:var(--text-2);text-decoration:none}
+.footer-col a:hover{color:var(--text)}
+.footer-bottom{
+  margin-top:52px;padding-top:22px;border-top:1px solid var(--hair);
+  display:flex;justify-content:space-between;gap:14px;flex-wrap:wrap;
+  font-family:var(--data);font-size:.74rem;color:var(--muted);
+}
+.footer-bottom a{color:var(--text-2)}
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width:1020px){
+  .footer-grid{grid-template-columns:1fr 1fr}
+  .impact-grid{grid-template-columns:1fr;gap:36px}
+  .band-grid{grid-template-columns:1fr 1fr}
+  .sensor-grid{grid-template-columns:1fr;gap:34px}
+}
+@media (max-width:820px){
+  .hero-grid{grid-template-columns:1fr;gap:40px;padding:56px 0}
+  .main-nav{display:none}
+  .map-shell{height:440px}
+}
+@media (max-width:600px){
+  .stat-tiles,.footer-grid,.band-grid{grid-template-columns:1fr}
+  .section{padding:60px 0}
+}
+
+/* ============================================================
+   REDUCED MOTION
+   ============================================================ */
+@media (prefers-reduced-motion:reduce){
+  html{scroll-behavior:auto}
+  .panel-live .pulse{animation:none}
+  .city-tabs button{transition:none}
+}
+</style>
+</head>
+<body>
+
+<!-- ============================================================
+     HEADER
+     ============================================================ -->
+<header class="site-header">
+  <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+  <div class="header-inner">
+    <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+    <nav class="main-nav" aria-label="Primary">
+      <a class="live-link" href="air.html" aria-current="page">Air</a>
+      <a href="water.html">Water</a>
+      <a href="sound.html">Sound</a>
+      <a href="radiation.html">Radiation</a>
+      <a href="data.html">Data</a>
+      <a href="stories.html">Stories</a>
+      <a href="about.html">About</a>
+    </nav>
+    <a class="nav-cta" href="get-started.html">Get a sensor</a>
+  </div>
+</header>
+
+<main>
+
+<!-- ============================================================
+     HERO — editorial headline + featured live reading
+     ============================================================ -->
+<section class="hero">
+  <div class="wrap hero-grid">
+    <div>
+      <p class="kicker">Air stream &middot; Live network &middot; PM<sub>2.5</sub> / PM<sub>10</sub></p>
+      <h1>We've tested the quality of <em>your city's air.</em></h1>
+      <p class="standfirst">
+        Hundreds of low-cost, citizen-hosted sensors measure the fine particulate matter —
+        PM<sub>2.5</sub> — that reaches deepest into human lungs. Every reading is open data:
+        evidence for journalists, ammunition for watchdogs, and a daily answer to a simple
+        question — <em>is it safe to breathe outside today?</em>
+      </p>
+      <div class="hero-actions">
+        <a class="btn btn-primary" href="get-started.html">Host an air sensor</a>
+        <a class="btn btn-ghost" href="data.html">Download the data</a>
+      </div>
+      <span class="proto-badge">Prototype &middot; illustrative data</span>
+    </div>
+
+    <!-- Featured reading panel (updated by the city selector below) -->
+    <aside class="reading-panel" aria-label="Featured air quality reading (sample data)" aria-live="polite">
+      <div class="panel-spine aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+      <div class="panel-top">
+        <span class="panel-city" id="feat-city">Nairobi, Kenya</span>
+        <span class="panel-live"><span class="pulse" aria-hidden="true"></span>Live reading</span>
+      </div>
+      <div class="big-reading">
+        <span class="num" id="feat-pm25">38.4</span>
+        <span class="unit-block">µg/m³<br>PM<sub>2.5</sub></span>
+      </div>
+      <span class="band-chip"><span class="swatch" id="feat-swatch" aria-hidden="true"></span><span id="feat-band">Unhealthy for sensitive groups</span></span>
+      <div class="aqi-meter">
+        <div class="track" aria-hidden="true">
+          <span style="background:var(--aqi-good)"></span><span style="background:var(--aqi-moderate)"></span><span style="background:var(--aqi-sensitive)"></span><span style="background:var(--aqi-unhealthy)"></span><span style="background:var(--aqi-veryunhealthy)"></span><span style="background:var(--aqi-hazardous)"></span>
+        </div>
+        <div class="needle" id="feat-needle" aria-hidden="true" style="left:35.8%"></div>
+        <div class="scale-labels" aria-hidden="true"><span>Good</span><span>Hazardous</span></div>
+      </div>
+      <div class="panel-meta">
+        <span>PM<sub>10</sub> <strong id="feat-pm10">51.2 µg/m³</strong></span>
+        <span>SDS011 &middot; Luftdaten network</span>
+        <span>Updated <strong id="feat-updated">just now</strong></span>
+      </div>
+    </aside>
+  </div>
+</section>
+
+<!-- ============================================================
+     CITY DASHBOARD — selector + 24-hour trend chart
+     (chart fully authored in markup; JS only re-themes it)
+     ============================================================ -->
+<section class="section" id="dashboard">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">City dashboard</p>
+        <h2 class="display">One day in your city's air</h2>
+      </div>
+      <p class="lede">Rush hours leave fingerprints. PM<sub>2.5</sub> climbs with the morning commute, eases at midday, and peaks again as the city drives home. Pick a city — the featured reading above and the chart below follow.</p>
+    </div>
+
+    <div class="city-tabs" role="group" aria-label="Choose a featured city" id="city-tabs">
+      <button type="button" data-city="nairobi" aria-pressed="true"><span class="dot" style="background:var(--aqi-sensitive)" aria-hidden="true"></span>Nairobi</button>
+      <button type="button" data-city="lagos" aria-pressed="false"><span class="dot" style="background:var(--aqi-unhealthy)" aria-hidden="true"></span>Lagos</button>
+      <button type="button" data-city="accra" aria-pressed="false"><span class="dot" style="background:var(--aqi-sensitive)" aria-hidden="true"></span>Accra</button>
+      <button type="button" data-city="dar" aria-pressed="false"><span class="dot" style="background:var(--aqi-moderate)" aria-hidden="true"></span>Dar es Salaam</button>
+      <button type="button" data-city="kano" aria-pressed="false"><span class="dot" style="background:var(--aqi-unhealthy)" aria-hidden="true"></span>Kano</button>
+      <button type="button" data-city="lusaka" aria-pressed="false"><span class="dot" style="background:var(--aqi-good)" aria-hidden="true"></span>Lusaka</button>
+    </div>
+    <p class="tabs-note">Dot = current PM<sub>2.5</sub> health band. Sample data for illustration.</p>
+
+    <div class="chart-card" id="trend-card">
+      <div class="chart-title-row">
+        <h3 id="trend-title">PM<sub>2.5</sub> over 24 hours — <span id="trend-city">Nairobi</span> (sample day)</h3>
+        <span class="sub">µg/m³ &middot; illustrative data</span>
+      </div>
+
+      <svg id="trend-chart" class="trend-svg" viewBox="0 0 760 360" role="img"
+           aria-label="Line chart of PM2.5 over 24 hours in Nairobi. Values fall overnight to 13 micrograms per cubic metre, rise to a morning-commute peak of 41 at 8am, dip after midday, and peak at 52 micrograms per cubic metre at 6pm — five times the WHO guideline of 10.">
+
+        <!-- gridlines: recessive hairlines -->
+        <g stroke="rgba(255,255,255,0.08)" stroke-width="1" shape-rendering="crispEdges">
+          <line id="grid-1" x1="52" y1="24"  x2="664" y2="24"></line>
+          <line id="grid-2" x1="52" y1="116" x2="664" y2="116"></line>
+          <line id="grid-3" x1="52" y1="208" x2="664" y2="208"></line>
+        </g>
+        <!-- baseline (x-axis) -->
+        <line x1="52" y1="300" x2="664" y2="300" stroke="rgba(255,255,255,0.16)" stroke-width="1" shape-rendering="crispEdges"></line>
+
+        <!-- y-axis tick labels -->
+        <g font-size="11" fill="var(--muted)" text-anchor="end" style="font-variant-numeric:tabular-nums">
+          <text x="44" y="304">0</text>
+          <text x="44" y="212" id="ytick-1">20</text>
+          <text x="44" y="120" id="ytick-2">40</text>
+          <text x="44" y="28"  id="ytick-3">60</text>
+        </g>
+
+        <!-- x-axis tick labels -->
+        <g font-size="11" fill="var(--muted)" text-anchor="middle" style="font-variant-numeric:tabular-nums">
+          <text x="52"    y="322" text-anchor="start">00:00</text>
+          <text x="211.7" y="322">06:00</text>
+          <text x="371.3" y="322">12:00</text>
+          <text x="531"   y="322">18:00</text>
+          <text x="664"   y="322" text-anchor="end">23:00</text>
+        </g>
+        <text x="52" y="345" font-size="10" fill="var(--muted)" id="x-caption">Hour of day (EAT) · sample values, hourly means</text>
+
+        <!-- WHO guideline reference line (threshold → dashed, labeled) -->
+        <line id="who-line" x1="52" y1="254" x2="664" y2="254" stroke="var(--aqi-good)" stroke-width="1.5" stroke-dasharray="6 5"></line>
+        <text id="who-label" x="58" y="248" font-size="10.5" fill="var(--text-2)" font-weight="500">WHO guideline (10 µg/m³)</text>
+
+        <!-- area wash under the line (~8% opacity) -->
+        <path id="trend-area" fill="#f5822e" opacity="0.08" d="M52,300 L52,217.2 L78.6,226.4 L105.2,231 L131.8,235.6 L158.4,240.2 L185,231 L211.7,198.8 L238.3,143.6 L264.9,111.4 L291.5,125.2 L318.1,152.8 L344.7,171.2 L371.3,180.4 L397.9,185 L424.5,175.8 L451.1,162 L477.7,134.4 L504.3,97.6 L531,60.8 L557.6,74.6 L584.2,93 L610.8,106.8 L637.4,116 L664,123.4 L664,300 Z"></path>
+
+        <!-- data line: 2px, round joins, fully visible with zero JS -->
+        <polyline id="trend-line" fill="none" stroke="#f5822e" stroke-width="2"
+                  stroke-linejoin="round" stroke-linecap="round"
+                  points="52,217.2 78.6,226.4 105.2,231 131.8,235.6 158.4,240.2 185,231 211.7,198.8 238.3,143.6 264.9,111.4 291.5,125.2 318.1,152.8 344.7,171.2 371.3,180.4 397.9,185 424.5,175.8 451.1,162 477.7,134.4 504.3,97.6 531,60.8 557.6,74.6 584.2,93 610.8,106.8 637.4,116 664,123.4"></polyline>
+
+        <!-- selective direct labels: the peak and the endpoint -->
+        <circle id="peak-dot" cx="531" cy="60.8" r="4.5" fill="#f5822e" stroke="var(--ink-2)" stroke-width="2"></circle>
+        <text id="peak-val" x="531" y="46" font-size="12" font-weight="700" fill="var(--text)" text-anchor="middle">52</text>
+        <text id="peak-lbl" x="531" y="33" font-size="9.5" fill="var(--text-2)" text-anchor="middle">evening peak</text>
+        <circle id="end-dot" cx="664" cy="123.4" r="4.5" fill="#f5822e" stroke="var(--ink-2)" stroke-width="2"></circle>
+        <text id="end-val" x="656" y="116" font-size="12" font-weight="700" fill="var(--text)" text-anchor="end">38.4</text>
+
+        <!-- hover layer (populated by JS as progressive enhancement) -->
+        <g id="trend-hover" aria-hidden="true"></g>
+      </svg>
+
+      <div class="chart-tip" id="trend-tip" role="status" aria-live="off"></div>
+
+      <details class="chart-table">
+        <summary>View this chart as a table</summary>
+        <table>
+          <caption class="sub" style="text-align:left;padding:4px 0;color:var(--muted)" id="trend-caption">Hourly PM2.5 (µg/m³), Nairobi — sample day</caption>
+          <tr><th scope="row">Hour</th><td>00</td><td>01</td><td>02</td><td>03</td><td>04</td><td>05</td><td>06</td><td>07</td><td>08</td><td>09</td><td>10</td><td>11</td></tr>
+          <tr id="trend-vals-a"><th scope="row">PM2.5</th><td>18</td><td>16</td><td>15</td><td>14</td><td>13</td><td>15</td><td>22</td><td>34</td><td>41</td><td>38</td><td>32</td><td>28</td></tr>
+          <tr><th scope="row">Hour</th><td>12</td><td>13</td><td>14</td><td>15</td><td>16</td><td>17</td><td>18</td><td>19</td><td>20</td><td>21</td><td>22</td><td>23</td></tr>
+          <tr id="trend-vals-b"><th scope="row">PM2.5</th><td>26</td><td>25</td><td>27</td><td>30</td><td>36</td><td>44</td><td>52</td><td>49</td><td>45</td><td>42</td><td>40</td><td>38.4</td></tr>
+        </table>
+      </details>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     CITY COMPARISON — horizontal bars, static markup
+     ============================================================ -->
+<section class="section" style="padding-top:0">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">Across the network</p>
+        <h2 class="display">Sixteen cities, ranked by what they breathe</h2>
+      </div>
+      <p class="lede">Current PM<sub>2.5</sub> across every monitored city, coloured by health band. The dashed line is the WHO annual guideline — 10 µg/m³. Most of the network sits well beyond it.</p>
+    </div>
+
+    <div class="chart-card">
+      <div class="chart-title-row">
+        <h3>Current PM<sub>2.5</sub> by city</h3>
+        <span class="sub">µg/m³ &middot; illustrative snapshot</span>
+      </div>
+
+      <svg id="compare-chart" class="trend-svg" viewBox="0 0 760 530" role="img"
+           aria-label="Horizontal bar chart ranking 16 African cities by current PM2.5. Maiduguri leads at 161 micrograms per cubic metre (very unhealthy), followed by Kano at 138.7 (unhealthy); Lusaka is lowest at 11.2 (good). Only Lusaka is near the WHO guideline of 10.">
+
+        <!-- vertical gridlines -->
+        <g stroke="rgba(255,255,255,0.08)" stroke-width="1" shape-rendering="crispEdges">
+          <line x1="313.3" y1="18" x2="313.3" y2="486"></line>
+          <line x1="486.7" y1="18" x2="486.7" y2="486"></line>
+          <line x1="660"   y1="18" x2="660"   y2="486"></line>
+        </g>
+        <!-- zero axis -->
+        <line x1="140" y1="18" x2="140" y2="486" stroke="rgba(255,255,255,0.16)" stroke-width="1" shape-rendering="crispEdges"></line>
+
+        <!-- WHO guideline marker -->
+        <line x1="168.9" y1="18" x2="168.9" y2="486" stroke="var(--aqi-good)" stroke-width="1.5" stroke-dasharray="6 5"></line>
+        <text x="175" y="14" font-size="10.5" fill="var(--text-2)" font-weight="500">WHO guideline (10 µg/m³)</text>
+
+        <!-- x-axis labels -->
+        <g font-size="11" fill="var(--muted)" text-anchor="middle" style="font-variant-numeric:tabular-nums">
+          <text x="140" y="504">0</text>
+          <text x="313.3" y="504">60</text>
+          <text x="486.7" y="504">120</text>
+          <text x="660" y="504">180</text>
+        </g>
+        <text x="672" y="504" font-size="10" fill="var(--muted)" text-anchor="start">µg/m³</text>
+        <text x="140" y="524" font-size="10" fill="var(--muted)">Current PM2.5 snapshot · sample values, coloured by EPA health band</text>
+
+        <!-- bars: rounded data-end, city label left, value label at end -->
+        <g font-size="11" style="font-variant-numeric:tabular-nums">
+          <g class="cbar"><title>Maiduguri, Nigeria — 161.0 µg/m³ · Very unhealthy</title>
+            <text x="130" y="38" fill="var(--text-2)" text-anchor="end">Maiduguri</text>
+            <path fill="#b06ae0" d="M140 26 h461.1 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="613.1" y="38" fill="var(--text)" font-weight="700">161.0</text></g>
+          <g class="cbar"><title>Kano, Nigeria — 138.7 µg/m³ · Unhealthy</title>
+            <text x="130" y="67" fill="var(--text-2)" text-anchor="end">Kano</text>
+            <path fill="#ef5350" d="M140 55 h396.7 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="548.7" y="67" fill="var(--text)" font-weight="700">138.7</text></g>
+          <g class="cbar"><title>Port Harcourt, Nigeria — 74.5 µg/m³ · Unhealthy</title>
+            <text x="130" y="96" fill="var(--text-2)" text-anchor="end">Port Harcourt</text>
+            <path fill="#ef5350" d="M140 84 h211.2 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="363.2" y="96" fill="var(--text)" font-weight="700">74.5</text></g>
+          <g class="cbar"><title>Lagos, Nigeria — 68.2 µg/m³ · Unhealthy</title>
+            <text x="130" y="125" fill="var(--text-2)" text-anchor="end">Lagos</text>
+            <path fill="#ef5350" d="M140 113 h193 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="345" y="125" fill="var(--text)" font-weight="700">68.2</text></g>
+          <g class="cbar"><title>Ilorin, Nigeria — 52.6 µg/m³ · Unhealthy for sensitive groups</title>
+            <text x="130" y="154" fill="var(--text-2)" text-anchor="end">Ilorin</text>
+            <path fill="#f5822e" d="M140 142 h148 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="300" y="154" fill="var(--text)" font-weight="700">52.6</text></g>
+          <g class="cbar"><title>Accra, Ghana — 47.3 µg/m³ · Unhealthy for sensitive groups</title>
+            <text x="130" y="183" fill="var(--text-2)" text-anchor="end">Accra</text>
+            <path fill="#f5822e" d="M140 171 h132.6 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="284.6" y="183" fill="var(--text)" font-weight="700">47.3</text></g>
+          <g class="cbar"><title>Abuja, Nigeria — 44.1 µg/m³ · Unhealthy for sensitive groups</title>
+            <text x="130" y="212" fill="var(--text-2)" text-anchor="end">Abuja</text>
+            <path fill="#f5822e" d="M140 200 h123.4 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="275.4" y="212" fill="var(--text)" font-weight="700">44.1</text></g>
+          <g class="cbar"><title>Awka, Nigeria — 41.9 µg/m³ · Unhealthy for sensitive groups</title>
+            <text x="130" y="241" fill="var(--text-2)" text-anchor="end">Awka</text>
+            <path fill="#f5822e" d="M140 229 h117 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="269" y="241" fill="var(--text)" font-weight="700">41.9</text></g>
+          <g class="cbar"><title>Nairobi, Kenya — 38.4 µg/m³ · Unhealthy for sensitive groups</title>
+            <text x="130" y="270" fill="var(--text-2)" text-anchor="end">Nairobi</text>
+            <path fill="#f5822e" d="M140 258 h106.9 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="258.9" y="270" fill="var(--text)" font-weight="700">38.4</text></g>
+          <g class="cbar"><title>Kumasi, Ghana — 35.9 µg/m³ · Unhealthy for sensitive groups</title>
+            <text x="130" y="299" fill="var(--text-2)" text-anchor="end">Kumasi</text>
+            <path fill="#f5822e" d="M140 287 h99.7 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="251.7" y="299" fill="var(--text)" font-weight="700">35.9</text></g>
+          <g class="cbar"><title>Akure, Nigeria — 33.5 µg/m³ · Moderate</title>
+            <text x="130" y="328" fill="var(--text-2)" text-anchor="end">Akure</text>
+            <path fill="#f4c542" d="M140 316 h92.8 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="244.8" y="328" fill="var(--text)" font-weight="700">33.5</text></g>
+          <g class="cbar"><title>Ado-Ekiti, Nigeria — 29.8 µg/m³ · Moderate</title>
+            <text x="130" y="357" fill="var(--text-2)" text-anchor="end">Ado-Ekiti</text>
+            <path fill="#f4c542" d="M140 345 h82.1 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="234.1" y="357" fill="var(--text)" font-weight="700">29.8</text></g>
+          <g class="cbar"><title>Dar es Salaam, Tanzania — 28.9 µg/m³ · Moderate</title>
+            <text x="130" y="386" fill="var(--text-2)" text-anchor="end">Dar es Salaam</text>
+            <path fill="#f4c542" d="M140 374 h79.5 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="231.5" y="386" fill="var(--text)" font-weight="700">28.9</text></g>
+          <g class="cbar"><title>Nakuru, Kenya — 21.7 µg/m³ · Moderate</title>
+            <text x="130" y="415" fill="var(--text-2)" text-anchor="end">Nakuru</text>
+            <path fill="#f4c542" d="M140 403 h58.7 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="210.7" y="415" fill="var(--text)" font-weight="700">21.7</text></g>
+          <g class="cbar"><title>Kisumu, Kenya — 17.3 µg/m³ · Moderate</title>
+            <text x="130" y="444" fill="var(--text-2)" text-anchor="end">Kisumu</text>
+            <path fill="#f4c542" d="M140 432 h46 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="198" y="444" fill="var(--text)" font-weight="700">17.3</text></g>
+          <g class="cbar"><title>Lusaka, Zambia — 11.2 µg/m³ · Good</title>
+            <text x="130" y="473" fill="var(--text-2)" text-anchor="end">Lusaka</text>
+            <path fill="#46d17f" d="M140 461 h28.4 a4 4 0 0 1 4 4 v8 a4 4 0 0 1 -4 4 H140 Z"></path>
+            <text x="180.4" y="473" fill="var(--text)" font-weight="700">11.2</text></g>
+        </g>
+      </svg>
+
+      <ul class="bar-legend" aria-label="Health band colour key">
+        <li><span class="sw" style="background:var(--aqi-good)"></span>Good ≤ 12</li>
+        <li><span class="sw" style="background:var(--aqi-moderate)"></span>Moderate ≤ 35.4</li>
+        <li><span class="sw" style="background:var(--aqi-sensitive)"></span>Sensitive ≤ 55.4</li>
+        <li><span class="sw" style="background:var(--aqi-unhealthy)"></span>Unhealthy ≤ 150.4</li>
+        <li><span class="sw" style="background:var(--aqi-veryunhealthy)"></span>Very unhealthy ≤ 250.4</li>
+        <li><span class="sw" style="background:var(--aqi-hazardous)"></span>Hazardous &gt; 250.4</li>
+      </ul>
+
+      <details class="chart-table">
+        <summary>View this chart as a table</summary>
+        <table>
+          <caption class="sub" style="text-align:left;padding:4px 0;color:var(--muted)">Current PM2.5 by city (µg/m³) — illustrative snapshot</caption>
+          <tr><th scope="col" style="text-align:left">City</th><th scope="col">PM2.5</th><th scope="col" style="text-align:left">Health band</th></tr>
+          <tr><td style="text-align:left">Maiduguri, Nigeria</td><td>161.0</td><td style="text-align:left">Very unhealthy</td></tr>
+          <tr><td style="text-align:left">Kano, Nigeria</td><td>138.7</td><td style="text-align:left">Unhealthy</td></tr>
+          <tr><td style="text-align:left">Port Harcourt, Nigeria</td><td>74.5</td><td style="text-align:left">Unhealthy</td></tr>
+          <tr><td style="text-align:left">Lagos, Nigeria</td><td>68.2</td><td style="text-align:left">Unhealthy</td></tr>
+          <tr><td style="text-align:left">Ilorin, Nigeria</td><td>52.6</td><td style="text-align:left">Unhealthy for sensitive groups</td></tr>
+          <tr><td style="text-align:left">Accra, Ghana</td><td>47.3</td><td style="text-align:left">Unhealthy for sensitive groups</td></tr>
+          <tr><td style="text-align:left">Abuja, Nigeria</td><td>44.1</td><td style="text-align:left">Unhealthy for sensitive groups</td></tr>
+          <tr><td style="text-align:left">Awka, Nigeria</td><td>41.9</td><td style="text-align:left">Unhealthy for sensitive groups</td></tr>
+          <tr><td style="text-align:left">Nairobi, Kenya</td><td>38.4</td><td style="text-align:left">Unhealthy for sensitive groups</td></tr>
+          <tr><td style="text-align:left">Kumasi, Ghana</td><td>35.9</td><td style="text-align:left">Unhealthy for sensitive groups</td></tr>
+          <tr><td style="text-align:left">Akure, Nigeria</td><td>33.5</td><td style="text-align:left">Moderate</td></tr>
+          <tr><td style="text-align:left">Ado-Ekiti, Nigeria</td><td>29.8</td><td style="text-align:left">Moderate</td></tr>
+          <tr><td style="text-align:left">Dar es Salaam, Tanzania</td><td>28.9</td><td style="text-align:left">Moderate</td></tr>
+          <tr><td style="text-align:left">Nakuru, Kenya</td><td>21.7</td><td style="text-align:left">Moderate</td></tr>
+          <tr><td style="text-align:left">Kisumu, Kenya</td><td>17.3</td><td style="text-align:left">Moderate</td></tr>
+          <tr><td style="text-align:left">Lusaka, Zambia</td><td>11.2</td><td style="text-align:left">Good</td></tr>
+        </table>
+      </details>
+    </div>
+    <p class="data-note">Prototype — illustrative data. Live data credited to the WHO Global Platform on Air Quality &amp; Health.</p>
+  </div>
+</section>
+
+<!-- ============================================================
+     MAP
+     ============================================================ -->
+<section class="section map-section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">The air network</p>
+        <h2 class="display">Where the sensors are breathing</h2>
+      </div>
+      <p class="lede">Each marker is a monitored city, coloured by its current PM<sub>2.5</sub> health band. Tap a marker for the reading.</p>
+    </div>
+    <div class="map-shell">
+      <p class="map-fallback-note" id="map-fallback">Interactive map — requires a network connection for basemap tiles.</p>
+      <div id="africa-map" aria-label="Map of monitored African cities coloured by air-quality band"></div>
+      <div class="map-count">
+        <div class="n">16<span style="color:var(--muted)">/</span>5</div>
+        <div class="l">cities / countries</div>
+      </div>
+      <div class="map-legend">
+        <div class="lg-title">PM2.5 health band (µg/m³)</div>
+        <ul>
+          <li><span class="sw" style="background:var(--aqi-good)"></span>Good ≤ 12</li>
+          <li><span class="sw" style="background:var(--aqi-moderate)"></span>Moderate ≤ 35.4</li>
+          <li><span class="sw" style="background:var(--aqi-sensitive)"></span>Sensitive ≤ 55.4</li>
+          <li><span class="sw" style="background:var(--aqi-unhealthy)"></span>Unhealthy ≤ 150.4</li>
+          <li><span class="sw" style="background:var(--aqi-veryunhealthy)"></span>Very unhealthy ≤ 250.4</li>
+          <li><span class="sw" style="background:var(--aqi-hazardous)"></span>Hazardous &gt; 250.4</li>
+        </ul>
+      </div>
+    </div>
+    <p class="data-note">Sample readings for illustration. Live data credited to the WHO Global Platform on Air Quality &amp; Health.</p>
+  </div>
+</section>
+
+<!-- ============================================================
+     HEALTH GUIDANCE — the six bands, explained
+     ============================================================ -->
+<section class="section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">Health guidance</p>
+        <h2 class="display">What the colours ask of you</h2>
+      </div>
+      <p class="lede">Every reading on this page is banded by the US&nbsp;EPA PM<sub>2.5</sub> scale. Here is what each band means — and what to do when your street turns that colour.</p>
+    </div>
+    <div class="band-grid">
+      <article class="band-card">
+        <span class="accent" style="background:var(--aqi-good)" aria-hidden="true"></span>
+        <div class="band-head">
+          <h3><span class="sw" style="background:var(--aqi-good)" aria-hidden="true"></span>Good</h3>
+          <span class="band-range">0 – 12 µg/m³</span>
+        </div>
+        <p class="meaning">Air quality poses little or no health risk. Particulate levels are near the cleanest the WHO considers safe.</p>
+        <p class="advice"><strong>What to do</strong>Enjoy it. Walk, run, cycle — and open the windows while it lasts.</p>
+      </article>
+      <article class="band-card">
+        <span class="accent" style="background:var(--aqi-moderate)" aria-hidden="true"></span>
+        <div class="band-head">
+          <h3><span class="sw" style="background:var(--aqi-moderate)" aria-hidden="true"></span>Moderate</h3>
+          <span class="band-range">12.1 – 35.4 µg/m³</span>
+        </div>
+        <p class="meaning">Acceptable for most people, but already above the WHO guideline. Unusually sensitive individuals may notice effects.</p>
+        <p class="advice"><strong>What to do</strong>If you're unusually sensitive to particle pollution, consider shortening intense outdoor exercise.</p>
+      </article>
+      <article class="band-card">
+        <span class="accent" style="background:var(--aqi-sensitive)" aria-hidden="true"></span>
+        <div class="band-head">
+          <h3><span class="sw" style="background:var(--aqi-sensitive)" aria-hidden="true"></span>Unhealthy for sensitive groups</h3>
+          <span class="band-range">35.5 – 55.4 µg/m³</span>
+        </div>
+        <p class="meaning">Children, older adults, pregnant people and anyone with heart or lung disease can start to feel effects.</p>
+        <p class="advice"><strong>What to do</strong>Sensitive groups: reduce prolonged or heavy exertion outdoors. Everyone else: watch for symptoms.</p>
+      </article>
+      <article class="band-card">
+        <span class="accent" style="background:var(--aqi-unhealthy)" aria-hidden="true"></span>
+        <div class="band-head">
+          <h3><span class="sw" style="background:var(--aqi-unhealthy)" aria-hidden="true"></span>Unhealthy</h3>
+          <span class="band-range">55.5 – 150.4 µg/m³</span>
+        </div>
+        <p class="meaning">Everyone may begin to experience effects — irritated airways, coughing, shortness of breath. Sensitive groups face more serious ones.</p>
+        <p class="advice"><strong>What to do</strong>Cut back outdoor exertion; move workouts indoors. Sensitive groups should avoid prolonged time outside.</p>
+      </article>
+      <article class="band-card">
+        <span class="accent" style="background:var(--aqi-veryunhealthy)" aria-hidden="true"></span>
+        <div class="band-head">
+          <h3><span class="sw" style="background:var(--aqi-veryunhealthy)" aria-hidden="true"></span>Very unhealthy</h3>
+          <span class="band-range">150.5 – 250.4 µg/m³</span>
+        </div>
+        <p class="meaning">Health alert: the risk of effects is increased for everyone, not just sensitive groups.</p>
+        <p class="advice"><strong>What to do</strong>Avoid prolonged exertion outdoors. Keep children and elders indoors; close windows, filter air if you can, mask up outside.</p>
+      </article>
+      <article class="band-card">
+        <span class="accent" style="background:var(--aqi-hazardous)" aria-hidden="true"></span>
+        <div class="band-head">
+          <h3><span class="sw" style="background:var(--aqi-hazardous)" aria-hidden="true"></span>Hazardous</h3>
+          <span class="band-range">&gt; 250.4 µg/m³</span>
+        </div>
+        <p class="meaning">Emergency conditions. The entire population is likely to be affected; this is the air of severe dust storms and open burning.</p>
+        <p class="advice"><strong>What to do</strong>Stay indoors with windows sealed. Avoid all outdoor activity. Follow local public-health alerts.</p>
+      </article>
+    </div>
+    <p class="data-note">Bands follow the US EPA breakpoints for 24-hour PM2.5. The WHO guideline (10 µg/m³ annual mean) is stricter than all but the Good band.</p>
+  </div>
+</section>
+
+<!-- ============================================================
+     WHY IT MATTERS — paper reading surface with impact stats
+     ============================================================ -->
+<section class="section paper-section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <p class="kicker">Why air, first</p>
+    <h2 class="display">The quiet emergency in every breath</h2>
+    <div class="impact-grid">
+      <div class="impact-prose">
+        <p>
+          Air pollution is linked to roughly <strong>one in nine deaths worldwide</strong> — a toll that
+          makes it one of the greatest environmental risks to health. The World Health Organization
+          attributes about <strong>seven million premature deaths every year</strong> to it: around
+          4.2&nbsp;million from ambient (outdoor) pollution and 3.8&nbsp;million from household air —
+          the smoke of indoor stoves and open fires.
+        </p>
+        <p>
+          The particles that do the damage are the ones you cannot see. PM<sub>2.5</sub> — fine
+          particulate matter under 2.5 microns wide — slips past the body's defences into the
+          bloodstream, driving strokes, heart disease, lung cancer and COPD. And across much of
+          Africa, the street-level data needed to fight it barely exists. That is the gap this
+          network was built to close: <strong>evidence, block by block, breath by breath.</strong>
+        </p>
+      </div>
+      <div class="stat-tiles" aria-label="Share of deaths linked to air pollution, by cause (WHO)">
+        <div class="stat-tile">
+          <div class="val">~36%</div>
+          <div class="lbl">of lung-cancer deaths are linked to air pollution</div>
+          <div class="bar" aria-hidden="true"><i style="width:36%;background:var(--aqi-hazardous)"></i></div>
+        </div>
+        <div class="stat-tile">
+          <div class="val">~35%</div>
+          <div class="lbl">of deaths from COPD are linked to air pollution</div>
+          <div class="bar" aria-hidden="true"><i style="width:35%;background:var(--aqi-veryunhealthy)"></i></div>
+        </div>
+        <div class="stat-tile">
+          <div class="val">~34%</div>
+          <div class="lbl">of stroke deaths are linked to air pollution</div>
+          <div class="bar" aria-hidden="true"><i style="width:34%;background:var(--aqi-unhealthy)"></i></div>
+        </div>
+        <div class="stat-tile">
+          <div class="val">~27%</div>
+          <div class="lbl">of heart-disease deaths are linked to air pollution</div>
+          <div class="bar" aria-hidden="true"><i style="width:27%;background:var(--aqi-sensitive)"></i></div>
+        </div>
+      </div>
+    </div>
+    <p class="paper-credit">Figures: World Health Organization. Air-quality data credited to the WHO Global Platform on Air Quality &amp; Health.</p>
+  </div>
+</section>
+
+<!-- ============================================================
+     HOW THE SENSORS WORK
+     ============================================================ -->
+<section class="section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">Under the hood</p>
+        <h2 class="display">A laser, a fan, and a Wi-Fi chip</h2>
+      </div>
+    </div>
+    <div class="sensor-grid">
+      <div class="sensor-prose">
+        <p>
+          Every air reading on this page comes from an <strong>SDS011 particulate sensor</strong> —
+          the workhorse of the open-source <strong>Luftdaten</strong> citizen-sensing movement. A small
+          fan draws air through a chamber where a laser beam scatters off airborne particles; from
+          that scatter the sensor counts what's floating in the air and reports
+          <strong>PM<sub>2.5</sub> and PM<sub>10</sub> concentrations in µg/m³</strong> every few minutes.
+        </p>
+        <p>
+          The sensor rides on a low-cost microcontroller that pushes each reading over
+          <strong>Wi-Fi — or GSM where connectivity is thin</strong> — to the open sensors.AFRICA
+          platform, where it is mapped, archived and published. The whole station costs about as
+          much as a pair of shoes, mounts on a window ledge, and is assembled by the citizens who
+          host it. That is the point: cheap enough for a household, honest enough for a newsroom.
+        </p>
+      </div>
+      <div class="spec-card">
+        <h3>Station at a glance</h3>
+        <dl>
+          <div class="spec-row" style="border-top:none"><dt>Sensor</dt><dd>Nova SDS011</dd></div>
+          <div class="spec-row"><dt>Method</dt><dd>Laser light scattering</dd></div>
+          <div class="spec-row"><dt>Measures</dt><dd>PM<sub>2.5</sub> &amp; PM<sub>10</sub> (µg/m³)</dd></div>
+          <div class="spec-row"><dt>Cadence</dt><dd>Every 2–5 minutes</dd></div>
+          <div class="spec-row"><dt>Uplink</dt><dd>Wi-Fi, GSM where needed</dd></div>
+          <div class="spec-row"><dt>Firmware</dt><dd>Open-source Luftdaten</dd></div>
+          <div class="spec-row"><dt>Data</dt><dd>Open — free to reuse</dd></div>
+        </dl>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     CTA
+     ============================================================ -->
+<section class="cta-section">
+  <div class="cta-inner">
+    <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <h2>Put your street on this page.</h2>
+    <p>Host an air sensor at your home, school or office and add your block to the public record. No lab coat required — just a window ledge and Wi-Fi.</p>
+    <a class="btn btn-primary" href="get-started.html">Get started — host a sensor</a>
+  </div>
+</section>
+
+</main>
+
+<!-- ============================================================
+     FOOTER
+     ============================================================ -->
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+        <p class="footer-mission">A pan-African citizen science initiative using sensors to monitor air, water and sound pollution — giving citizens actionable information about their cities.</p>
+      </div>
+      <div class="footer-col">
+        <h4>Network</h4>
+        <ul>
+          <li><a href="air.html">Air quality</a></li>
+          <li><a href="water.html">Water</a></li>
+          <li><a href="sound.html">Sound</a></li>
+          <li><a href="radiation.html">Radiation</a></li>
+          <li><a href="data.html">Open data</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Community</h4>
+        <ul>
+          <li><a href="stories.html">Stories</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="get-started.html">Get a sensor</a></li>
+          <li><a href="https://twitter.com/sensorsAFRICA/" rel="noopener">Twitter</a></li>
+          <li><a href="https://www.instagram.com/sensorsAFRICA/" rel="noopener">Instagram</a></li>
+          <li><a href="https://medium.com/@sensors.AFRICA" rel="noopener">Medium</a></li>
+          <li><a href="https://github.com/CodeForAfrica/sensors.AFRICA" rel="noopener">GitHub</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Partners</h4>
+        <ul>
+          <li><a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a></li>
+          <li><a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a></li>
+          <li><a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>Incubated by <a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a> · seed-funded by <a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a> · powered by <a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></span>
+      <span>Redesign prototype — all readings on this page are illustrative sample data.</span>
+    </div>
+  </div>
+</footer>
+
+<!-- ============================================================
+     SCRIPT 1 — MAP (isolated; failure here cannot affect charts)
+     ============================================================ -->
+<script>
+try {
+  // EPA PM2.5 breakpoints → AQI band color + name
+  function aqiBandMap(v){
+    if (v <= 12)    return { color:'#46d17f', name:'Good' };
+    if (v <= 35.4)  return { color:'#f4c542', name:'Moderate' };
+    if (v <= 55.4)  return { color:'#f5822e', name:'Unhealthy for sensitive groups' };
+    if (v <= 150.4) return { color:'#ef5350', name:'Unhealthy' };
+    if (v <= 250.4) return { color:'#b06ae0', name:'Very unhealthy' };
+    return { color:'#c0466c', name:'Hazardous' };
+  }
+
+  var MAP_CITIES = [
+    { name:'Nairobi',        country:'Kenya',    lat:-1.2864,  lng:36.8172,  pm25:38.4 },
+    { name:'Nakuru',         country:'Kenya',    lat:-0.3031,  lng:36.0800,  pm25:21.7 },
+    { name:'Kisumu',         country:'Kenya',    lat:-0.0917,  lng:34.7680,  pm25:17.3 },
+    { name:'Dar es Salaam',  country:'Tanzania', lat:-6.7924,  lng:39.2083,  pm25:28.9 },
+    { name:'Lagos',          country:'Nigeria',  lat:6.5244,   lng:3.3792,   pm25:68.2 },
+    { name:'Abuja',          country:'Nigeria',  lat:9.0765,   lng:7.3986,   pm25:44.1 },
+    { name:'Ilorin',         country:'Nigeria',  lat:8.4966,   lng:4.5421,   pm25:52.6 },
+    { name:'Maiduguri',      country:'Nigeria',  lat:11.8333,  lng:13.1510,  pm25:161.0 },
+    { name:'Port Harcourt',  country:'Nigeria',  lat:4.8156,   lng:7.0498,   pm25:74.5 },
+    { name:'Kano',           country:'Nigeria',  lat:12.0022,  lng:8.5920,   pm25:138.7 },
+    { name:'Awka',           country:'Nigeria',  lat:6.2120,   lng:7.0740,   pm25:41.9 },
+    { name:'Akure',          country:'Nigeria',  lat:7.2571,   lng:5.2058,   pm25:33.5 },
+    { name:'Ado-Ekiti',      country:'Nigeria',  lat:7.6233,   lng:5.2210,   pm25:29.8 },
+    { name:'Accra',          country:'Ghana',    lat:5.6037,   lng:-0.1870,  pm25:47.3 },
+    { name:'Kumasi',         country:'Ghana',    lat:6.6885,   lng:-1.6244,  pm25:35.9 },
+    { name:'Lusaka',         country:'Zambia',   lat:-15.3875, lng:28.3228,  pm25:11.2 }
+  ];
+
+  if (typeof L !== 'undefined') {
+    var map = L.map('africa-map', {
+      center: [2.5, 18],
+      zoom: 4,
+      minZoom: 3,
+      maxZoom: 10,
+      scrollWheelZoom: false,
+      attributionControl: true
+    });
+
+    // CARTO dark basemap — the shell behind it carries a styled fallback
+    // background, so a tile failure never looks broken.
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>',
+      subdomains: 'abcd',
+      maxZoom: 19
+    }).addTo(map);
+
+    MAP_CITIES.forEach(function (c) {
+      var band = aqiBandMap(c.pm25);
+      L.circleMarker([c.lat, c.lng], {
+        radius: 8,
+        color: '#0c0f16',       // 2px surface ring so overlapping markers stay legible
+        weight: 2,
+        fillColor: band.color,
+        fillOpacity: 0.95
+      }).addTo(map).bindPopup(
+        '<div class="popup-city">' + c.name + ', ' + c.country + '</div>' +
+        '<div class="popup-reading">PM2.5 <strong>' + c.pm25.toFixed(1) + ' µg/m³</strong></div>' +
+        '<div style="color:' + band.color + ';font-size:.75rem;margin-top:2px">&#9679; <span style="color:#9aa2b1">' + band.name + '</span></div>' +
+        '<div style="color:#6b7280;font-size:.68rem;margin-top:4px">Sample reading — illustrative</div>'
+      );
+    });
+
+    // Map is live: retire the static fallback note
+    var note = document.getElementById('map-fallback');
+    if (note) note.style.display = 'none';
+  }
+} catch (err) {
+  // Map failure is cosmetic: the shell keeps its styled fallback background.
+  console.warn('Map init skipped:', err && err.message);
+}
+</script>
+
+<!-- ============================================================
+     SCRIPT 2 — TREND CHART hover layer (progressive enhancement
+     only; the chart is fully rendered in static markup above)
+     ============================================================ -->
+<script>
+try {
+  // Shared state so the city selector (script 3) can retarget the hover data.
+  window.airTrendState = window.airTrendState || {
+    series: [18,16,15,14,13,15,22,34,41,38,32,28,26,25,27,30,36,44,52,49,45,42,40,38.4],
+    ys: 276 / 60
+  };
+
+  var svg  = document.getElementById('trend-chart');
+  var card = document.getElementById('trend-card');
+  var tip  = document.getElementById('trend-tip');
+  var hoverG = document.getElementById('trend-hover');
+
+  if (svg && card && tip && hoverG) {
+    var SVGNS = 'http://www.w3.org/2000/svg';
+    var X0 = 52, XW = 612, Y0 = 300;
+
+    // wide hover hit area (whole plot), nearest-point crosshair + dot
+    var cross = document.createElementNS(SVGNS, 'line');
+    cross.setAttribute('stroke', 'rgba(255,255,255,0.25)');
+    cross.setAttribute('stroke-width', '1');
+    cross.setAttribute('y1', '24'); cross.setAttribute('y2', '300');
+    cross.style.display = 'none';
+    hoverG.appendChild(cross);
+
+    var dot = document.createElementNS(SVGNS, 'circle');
+    dot.setAttribute('r', '5');
+    dot.setAttribute('fill', '#f5822e');
+    dot.setAttribute('stroke', '#141821');
+    dot.setAttribute('stroke-width', '2');
+    dot.style.display = 'none';
+    hoverG.appendChild(dot);
+    window.airTrendState.hoverDot = dot;   // selector re-colors it on city change
+
+    function hideHover(){ cross.style.display = 'none'; dot.style.display = 'none'; tip.style.display = 'none'; }
+
+    svg.addEventListener('mousemove', function (e) {
+      var s = window.airTrendState;
+      var rect = svg.getBoundingClientRect();
+      var sx = 760 / rect.width;                     // CSS px → viewBox units
+      var vx = (e.clientX - rect.left) * sx;
+      if (vx < X0 - 10 || vx > X0 + XW + 10) { hideHover(); return; }
+      var i = Math.round((vx - X0) / (XW / 23));
+      i = Math.max(0, Math.min(23, i));
+      var px = X0 + i * (XW / 23);
+      var py = Y0 - s.series[i] * s.ys;
+
+      cross.setAttribute('x1', px); cross.setAttribute('x2', px);
+      cross.style.display = '';
+      dot.setAttribute('cx', px); dot.setAttribute('cy', py);
+      dot.style.display = '';
+
+      tip.textContent = String(i).padStart(2, '0') + ':00 — ' + s.series[i] + ' µg/m³';
+      tip.style.display = 'block';
+      var cardRect = card.getBoundingClientRect();
+      tip.style.left = ((px / 760) * rect.width + rect.left - cardRect.left) + 'px';
+      tip.style.top  = ((py / 360) * rect.height + rect.top - cardRect.top) + 'px';
+    });
+    svg.addEventListener('mouseleave', hideHover);
+  }
+} catch (err) {
+  console.warn('Chart hover enhancement skipped:', err && err.message);
+}
+</script>
+
+<!-- ============================================================
+     SCRIPT 3 — CITY SELECTOR interaction (isolated; the page is
+     fully readable with zero JS — Nairobi is baked into markup)
+     ============================================================ -->
+<script>
+try {
+  function aqiBandSel(v){
+    var B = [
+      { lo:0,     hi:12,    color:'#46d17f', name:'Good' },
+      { lo:12,    hi:35.4,  color:'#f4c542', name:'Moderate' },
+      { lo:35.4,  hi:55.4,  color:'#f5822e', name:'Unhealthy for sensitive groups' },
+      { lo:55.4,  hi:150.4, color:'#ef5350', name:'Unhealthy' },
+      { lo:150.4, hi:250.4, color:'#b06ae0', name:'Very unhealthy' },
+      { lo:250.4, hi:350,   color:'#c0466c', name:'Hazardous' }
+    ];
+    for (var i = 0; i < B.length; i++) {
+      if (v <= B[i].hi || i === B.length - 1) {
+        var frac = Math.min(1, Math.max(0, (v - B[i].lo) / (B[i].hi - B[i].lo)));
+        return { i:i, color:B[i].color, name:B[i].name, meterPct: ((i + frac) / 6) * 100 };
+      }
+    }
+  }
+
+  var DASH = {
+    nairobi: { label:'Nairobi', country:'Kenya', tz:'EAT', pm10:51.2,
+      series:[18,16,15,14,13,15,22,34,41,38,32,28,26,25,27,30,36,44,52,49,45,42,40,38.4] },
+    lagos:   { label:'Lagos', country:'Nigeria', tz:'WAT', pm10:89.5,
+      series:[42,39,37,35,36,41,55,72,84,79,70,64,58,55,57,61,68,79,88,83,77,73,70,68.2] },
+    accra:   { label:'Accra', country:'Ghana', tz:'GMT', pm10:63.8,
+      series:[26,24,22,21,22,26,35,48,56,52,46,41,38,36,38,42,49,58,63,58,54,51,49,47.3] },
+    dar:     { label:'Dar es Salaam', country:'Tanzania', tz:'EAT', pm10:42.6,
+      series:[15,14,13,12,12,14,19,27,33,31,27,24,22,21,22,25,29,34,38,35,32,31,30,28.9] },
+    kano:    { label:'Kano', country:'Nigeria', tz:'WAT', pm10:214.9,
+      series:[96,92,88,85,88,97,112,128,142,150,146,138,130,124,120,124,131,142,155,151,147,143,140,138.7] },
+    lusaka:  { label:'Lusaka', country:'Zambia', tz:'CAT', pm10:19.4,
+      series:[7,6,6,5,5,6,9,13,16,15,13,11,10,9,10,11,13,16,18,16,14,13,12,11.2] }
+  };
+
+  var X0 = 52, XW = 612, Y0 = 300, YH = 276;
+  var YMAXES = [30, 60, 90, 120, 150, 180, 240, 300];
+
+  function $(id){ return document.getElementById(id); }
+  function fmt(v){ return (Math.round(v * 10) / 10).toString(); }
+
+  function renderCity(key){
+    var c = DASH[key];
+    if (!c) return;
+    var now = c.series[c.series.length - 1];
+    var band = aqiBandSel(now);
+
+    /* --- featured reading panel --- */
+    $('feat-city').textContent = c.label + ', ' + c.country;
+    var num = $('feat-pm25');
+    num.textContent = fmt(now);
+    num.style.color = band.color;
+    $('feat-band').textContent = band.name;
+    $('feat-swatch').style.background = band.color;
+    $('feat-needle').style.left = band.meterPct.toFixed(1) + '%';
+    $('feat-pm10').textContent = fmt(c.pm10) + ' µg/m³';
+
+    /* --- trend chart geometry --- */
+    var peakV = Math.max.apply(null, c.series);
+    var ymax = YMAXES[YMAXES.length - 1];
+    for (var m = 0; m < YMAXES.length; m++) {
+      if (YMAXES[m] >= peakV * 1.05) { ymax = YMAXES[m]; break; }
+    }
+    var ys = YH / ymax;
+    var pts = [], peakI = 0;
+    for (var i = 0; i < 24; i++) {
+      var px = X0 + i * (XW / 23);
+      var py = Y0 - c.series[i] * ys;
+      pts.push(px.toFixed(1) + ',' + py.toFixed(1));
+      if (c.series[i] > c.series[peakI]) peakI = i;
+    }
+    $('trend-line').setAttribute('points', pts.join(' '));
+    $('trend-line').setAttribute('stroke', band.color);
+    $('trend-area').setAttribute('d', 'M52,300 L' + pts.join(' L') + ' L664,300 Z');
+    $('trend-area').setAttribute('fill', band.color);
+
+    /* y ticks: thirds of a round ymax */
+    $('ytick-1').textContent = Math.round(ymax / 3);
+    $('ytick-2').textContent = Math.round(2 * ymax / 3);
+    $('ytick-3').textContent = ymax;
+
+    /* WHO guideline line */
+    var whoY = Y0 - 10 * ys;
+    $('who-line').setAttribute('y1', whoY.toFixed(1));
+    $('who-line').setAttribute('y2', whoY.toFixed(1));
+    $('who-label').setAttribute('y', (whoY - 6).toFixed(1));
+
+    /* peak + endpoint direct labels */
+    var peakX = X0 + peakI * (XW / 23), peakY = Y0 - c.series[peakI] * ys;
+    var lblX = Math.min(Math.max(peakX, 80), 620);
+    $('peak-dot').setAttribute('cx', peakX.toFixed(1));
+    $('peak-dot').setAttribute('cy', peakY.toFixed(1));
+    $('peak-dot').setAttribute('fill', band.color);
+    $('peak-val').setAttribute('x', lblX.toFixed(1));
+    $('peak-val').setAttribute('y', Math.max(14, peakY - 14.8).toFixed(1));
+    $('peak-val').textContent = fmt(c.series[peakI]);
+    $('peak-lbl').setAttribute('x', lblX.toFixed(1));
+    $('peak-lbl').setAttribute('y', Math.max(4, peakY - 27.8).toFixed(1));
+    $('peak-lbl').textContent = peakI >= 15 ? 'evening peak' : 'morning peak';
+    var endY = Y0 - now * ys;
+    $('end-dot').setAttribute('cy', endY.toFixed(1));
+    $('end-dot').setAttribute('fill', band.color);
+    $('end-val').setAttribute('y', (endY - 7).toFixed(1));
+    $('end-val').textContent = fmt(now);
+
+    /* titles, captions, accessibility text */
+    $('trend-city').textContent = c.label;
+    $('x-caption').textContent = 'Hour of day (' + c.tz + ') · sample values, hourly means';
+    $('trend-chart').setAttribute('aria-label',
+      'Line chart of PM2.5 over 24 hours in ' + c.label + '. Values peak at ' +
+      fmt(c.series[peakI]) + ' micrograms per cubic metre and currently read ' + fmt(now) +
+      ', against the WHO guideline of 10.');
+    $('trend-caption').textContent = 'Hourly PM2.5 (µg/m³), ' + c.label + ' — sample day';
+
+    /* table rows */
+    function rowHTML(vals){
+      var h = '<th scope="row">PM2.5</th>';
+      for (var k = 0; k < vals.length; k++) h += '<td>' + fmt(vals[k]) + '</td>';
+      return h;
+    }
+    $('trend-vals-a').innerHTML = rowHTML(c.series.slice(0, 12));
+    $('trend-vals-b').innerHTML = rowHTML(c.series.slice(12));
+
+    /* retarget the hover layer (script 2) */
+    window.airTrendState = window.airTrendState || {};
+    window.airTrendState.series = c.series;
+    window.airTrendState.ys = ys;
+    if (window.airTrendState.hoverDot) window.airTrendState.hoverDot.setAttribute('fill', band.color);
+  }
+
+  var tabs = $('city-tabs');
+  if (tabs) {
+    var buttons = tabs.querySelectorAll('button[data-city]');
+    buttons.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        buttons.forEach(function (b) { b.setAttribute('aria-pressed', b === btn ? 'true' : 'false'); });
+        renderCity(btn.getAttribute('data-city'));
+      });
+    });
+  }
+
+  /* Timestamp the featured panel with a plausible "last updated" time */
+  var updated = $('feat-updated');
+  if (updated) {
+    var nowD = new Date();
+    updated.textContent = String(nowD.getHours()).padStart(2, '0') + ':' +
+                          String(nowD.getMinutes()).padStart(2, '0') + ' local';
+  }
+} catch (err) {
+  console.warn('City selector enhancement skipped:', err && err.message);
+}
+</script>
+
+</body>
+</html>

--- a/redesign/data.html
+++ b/redesign/data.html
@@ -1,0 +1,692 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Open data — sensors.AFRICA</title>
+<meta name="description" content="sensors.AFRICA publishes open, real-time and historical air-quality data for African cities — embeddable widgets, a public API and downloadable archives for journalists, researchers and civic watchdogs.">
+
+<!-- Fonts: Fraunces (display serif) · Space Grotesk (data) · Inter (body) -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Space+Grotesk:wght@400;500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+
+<style>
+/* ============================================================
+   TOKENS — shared with all subpages, do not diverge
+   ============================================================ */
+:root{
+  --ink:#0c0f16; --ink-2:#141821; --ink-3:#1a1f2b;
+  --paper:#f1eee7; --paper-ink:#17140f;
+  --text:#e9ebf0; --text-2:#9aa2b1; --muted:#6b7280;
+  --hair:rgba(255,255,255,0.09); --hair-strong:rgba(255,255,255,0.16);
+  --aqi-good:#46d17f; --aqi-moderate:#f4c542; --aqi-sensitive:#f5822e;
+  --aqi-unhealthy:#ef5350; --aqi-veryunhealthy:#b06ae0; --aqi-hazardous:#c0466c;
+  --serif:"Fraunces",Georgia,serif;
+  --sans:"Inter",system-ui,-apple-system,sans-serif;
+  --data:"Space Grotesk","Inter",system-ui,sans-serif;
+  --maxw:1200px;
+}
+
+/* ============================================================
+   BASE
+   ============================================================ */
+*{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  background:var(--ink); color:var(--text);
+  font-family:var(--sans); font-size:16px; line-height:1.6;
+  -webkit-font-smoothing:antialiased;
+}
+img{max-width:100%;display:block}
+a{color:inherit}
+:focus-visible{outline:2px solid var(--aqi-moderate);outline-offset:3px;border-radius:2px}
+::selection{background:var(--aqi-sensitive);color:var(--ink)}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
+.kicker{
+  font-family:var(--data);font-size:.75rem;font-weight:500;
+  letter-spacing:.18em;text-transform:uppercase;color:var(--text-2);
+}
+.section-head{display:flex;align-items:baseline;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-bottom:8px}
+h2.display{
+  font-family:var(--serif);font-weight:600;font-size:clamp(1.7rem,3.4vw,2.6rem);
+  line-height:1.12;letter-spacing:-.01em;margin:10px 0 14px;
+}
+.lede{color:var(--text-2);max-width:56ch}
+
+/* The AQI spine — a segmented band used as the page's structural accent */
+.aqi-spine{display:flex;height:4px;width:100%}
+.aqi-spine span{flex:1}
+.aqi-spine .s1{background:var(--aqi-good)}
+.aqi-spine .s2{background:var(--aqi-moderate)}
+.aqi-spine .s3{background:var(--aqi-sensitive)}
+.aqi-spine .s4{background:var(--aqi-unhealthy)}
+.aqi-spine .s5{background:var(--aqi-veryunhealthy)}
+.aqi-spine .s6{background:var(--aqi-hazardous)}
+.spine-sm{width:64px;height:4px;margin-bottom:14px}
+
+/* ============================================================
+   HEADER
+   ============================================================ */
+.site-header{
+  position:sticky;top:0;z-index:1000;
+  background:rgba(12,15,22,.88);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+  border-bottom:1px solid var(--hair);
+}
+.header-inner{
+  max-width:var(--maxw);margin:0 auto;padding:0 24px;
+  display:flex;align-items:center;justify-content:space-between;gap:20px;height:64px;
+}
+.wordmark{
+  font-family:var(--data);font-weight:700;font-size:1.05rem;letter-spacing:.01em;
+  text-decoration:none;white-space:nowrap;
+}
+.wordmark .dot-africa{color:var(--aqi-good)}
+.main-nav{display:flex;gap:2px;align-items:center;overflow-x:auto}
+.main-nav a{
+  font-family:var(--data);font-size:.82rem;font-weight:500;color:var(--text-2);
+  text-decoration:none;padding:8px 11px;border-radius:6px;white-space:nowrap;
+}
+.main-nav a:hover{color:var(--text);background:var(--ink-3)}
+.main-nav a.live-link{color:var(--text)}
+.main-nav a.live-link::before{
+  content:"";display:inline-block;width:6px;height:6px;border-radius:50%;
+  background:var(--aqi-good);margin-right:7px;vertical-align:1px;
+}
+.main-nav a[aria-current="page"]{color:var(--text);background:var(--ink-3)}
+.nav-cta{
+  font-family:var(--data);font-size:.82rem;font-weight:700;text-decoration:none;
+  color:var(--ink);background:var(--aqi-good);padding:9px 16px;border-radius:999px;white-space:nowrap;
+}
+.nav-cta:hover{background:#5fdd92}
+
+/* ============================================================
+   SHARED SECTION / BUTTON / CTA CHROME (same as landing)
+   ============================================================ */
+.section{padding:84px 0}
+.btn{
+  font-family:var(--data);font-weight:700;font-size:.92rem;text-decoration:none;
+  padding:13px 24px;border-radius:999px;display:inline-block;
+}
+.btn-primary{background:var(--aqi-good);color:var(--ink)}
+.btn-primary:hover{background:#5fdd92}
+.btn-ghost{color:var(--text);border:1px solid var(--hair-strong)}
+.btn-ghost:hover{border-color:var(--text-2)}
+.proto-badge{
+  display:inline-flex;align-items:center;gap:7px;margin-top:26px;
+  font-family:var(--data);font-size:.68rem;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--muted);border:1px solid var(--hair);border-radius:999px;padding:5px 12px;
+}
+.proto-badge::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--aqi-moderate)}
+.cta-section{position:relative;overflow:hidden;border-top:1px solid var(--hair)}
+.cta-section::before{
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:radial-gradient(50rem 26rem at 50% 120%, rgba(70,209,127,.1), transparent 65%);
+}
+.cta-inner{position:relative;text-align:center;padding:96px 24px;max-width:760px;margin:0 auto}
+.cta-inner h2{
+  font-family:var(--serif);font-weight:640;font-size:clamp(2rem,4.4vw,3.3rem);
+  line-height:1.08;letter-spacing:-.015em;
+}
+.cta-inner p{margin:20px auto 32px;color:var(--text-2);max-width:46ch}
+.cta-inner .aqi-spine{width:120px;margin:0 auto 28px}
+
+/* ============================================================
+   PAGE HERO — editorial, data-hub flavour
+   ============================================================ */
+.data-hero{position:relative;overflow:hidden;border-bottom:1px solid var(--hair)}
+.data-hero::before{
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:
+    radial-gradient(52rem 30rem at 82% -12%, rgba(70,209,127,.08), transparent 60%),
+    radial-gradient(44rem 26rem at 4% 115%, rgba(245,130,46,.06), transparent 60%);
+}
+.data-hero .hero-inner{position:relative;padding:80px 0 70px;max-width:820px}
+.data-hero h1{
+  font-family:var(--serif);font-weight:640;font-variation-settings:"opsz" 100;
+  font-size:clamp(2.5rem,5.4vw,4.1rem);line-height:1.05;letter-spacing:-.015em;margin-top:14px;
+}
+.data-hero h1 em{font-style:italic;font-weight:520;color:var(--aqi-good)}
+.data-hero .standfirst{margin-top:22px;font-size:1.08rem;color:var(--text-2);max-width:60ch}
+.hero-facts{
+  display:flex;gap:28px;flex-wrap:wrap;margin-top:32px;
+  font-family:var(--data);font-size:.8rem;color:var(--text-2);
+}
+.hero-facts .fact strong{
+  display:block;font-size:1.25rem;font-weight:700;color:var(--text);
+  font-variant-numeric:tabular-nums;
+}
+.hero-credit{margin-top:30px;font-family:var(--data);font-size:.74rem;color:var(--muted)}
+.hero-credit strong{color:var(--text-2);font-weight:500}
+
+/* ============================================================
+   EMBED WIDGETS
+   ============================================================ */
+.embed-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:34px}
+.embed-card{
+  background:var(--ink-2);border:1px solid var(--hair);border-radius:14px;
+  padding:24px 22px 22px;position:relative;overflow:hidden;display:flex;flex-direction:column;
+}
+.embed-card .accent{position:absolute;top:0;left:0;right:0;height:3px}
+.embed-card h3{font-family:var(--serif);font-size:1.3rem;font-weight:600;margin-bottom:8px}
+.embed-card>p{font-size:.88rem;color:var(--text-2);margin-bottom:16px}
+.embed-preview{
+  border:1px solid var(--hair);border-radius:10px;background:var(--ink);
+  margin-bottom:16px;overflow:hidden;
+}
+.embed-preview svg{width:100%;height:auto;display:block}
+.snippet{position:relative;margin-top:auto}
+.snippet-label{
+  font-family:var(--data);font-size:.62rem;font-weight:700;letter-spacing:.14em;
+  text-transform:uppercase;color:var(--muted);margin-bottom:7px;
+}
+.snippet pre{
+  background:var(--ink);border:1px solid var(--hair);border-radius:8px;
+  padding:12px 14px;overflow-x:auto;
+}
+.snippet code{
+  font-family:var(--data);font-size:.76rem;line-height:1.55;color:var(--text-2);
+  white-space:pre;
+}
+.snippet code .u{color:var(--aqi-good)}
+.snippet code .t{color:var(--aqi-moderate)}
+.snippet+.snippet{margin-top:14px}
+.copy-btn{
+  position:absolute;top:26px;right:8px;
+  font-family:var(--data);font-size:.66rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase;
+  color:var(--text-2);background:var(--ink-3);border:1px solid var(--hair-strong);
+  border-radius:6px;padding:4px 9px;cursor:pointer;
+}
+.copy-btn:hover{color:var(--text);border-color:var(--text-2)}
+.copy-btn.copied{color:var(--aqi-good);border-color:rgba(70,209,127,.5)}
+.embed-note{margin-top:22px;font-family:var(--data);font-size:.78rem;color:var(--muted);max-width:74ch}
+.embed-note code{
+  font-family:var(--data);font-size:.76rem;color:var(--aqi-moderate);
+  background:var(--ink-2);border:1px solid var(--hair);border-radius:5px;padding:1px 6px;
+}
+
+/* ============================================================
+   API + ARCHIVES (resource cards on paper band)
+   ============================================================ */
+.paper-section{background:var(--paper);color:var(--paper-ink)}
+.paper-section .kicker{color:#6d675c}
+.paper-section h2.display{color:var(--paper-ink)}
+.paper-section .lede{color:#4d473c}
+.resource-grid{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin-top:34px}
+.resource-card{
+  background:#fff;border:1px solid #e2ddd1;border-radius:14px;padding:28px 26px;
+  display:flex;flex-direction:column;
+}
+.resource-card .r-kicker{
+  font-family:var(--data);font-size:.64rem;font-weight:700;letter-spacing:.16em;
+  text-transform:uppercase;color:#8a8375;margin-bottom:12px;
+}
+.resource-card h3{font-family:var(--serif);font-size:1.45rem;font-weight:600;margin-bottom:10px;color:var(--paper-ink)}
+.resource-card p{font-size:.92rem;color:#4d473c}
+.resource-card ul{
+  list-style:none;margin:16px 0 4px;font-family:var(--data);font-size:.82rem;color:#4d473c;
+}
+.resource-card li{
+  padding:7px 0;border-top:1px solid #ece8dd;display:flex;gap:10px;align-items:baseline;
+}
+.resource-card li::before{content:"→";color:var(--aqi-sensitive);font-weight:700;flex:none}
+.resource-links{margin-top:auto;padding-top:20px;display:flex;gap:10px;flex-wrap:wrap}
+.resource-links a{
+  font-family:var(--data);font-size:.8rem;font-weight:700;text-decoration:none;
+  color:var(--paper-ink);border:1px solid #d6d0c2;border-radius:999px;padding:9px 18px;
+}
+.resource-links a:hover{border-color:var(--paper-ink)}
+.resource-links a.solid{background:var(--paper-ink);color:var(--paper);border-color:var(--paper-ink)}
+.resource-links a.solid:hover{background:#000}
+.api-endpoint{
+  font-family:var(--data);font-size:.78rem;color:#4d473c;
+  background:#f7f4ec;border:1px solid #e2ddd1;border-radius:8px;
+  padding:11px 14px;margin-top:16px;white-space:pre-wrap;overflow-wrap:anywhere;
+}
+.api-endpoint b{color:var(--paper-ink)}
+
+/* ============================================================
+   LICENCE + PROVENANCE
+   ============================================================ */
+.terms-grid{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin-top:34px}
+.term-card{
+  background:var(--ink-2);border:1px solid var(--hair);border-radius:14px;padding:28px 26px;
+  position:relative;overflow:hidden;
+}
+.term-card .accent{position:absolute;top:0;left:0;bottom:0;width:3px}
+.term-card h3{font-family:var(--serif);font-size:1.35rem;font-weight:600;margin-bottom:10px}
+.term-card p{font-size:.9rem;color:var(--text-2)}
+.term-card p+p{margin-top:12px}
+.term-card a{color:var(--text)}
+.term-card .attr-line{
+  margin-top:16px;font-family:var(--data);font-size:.78rem;color:var(--text-2);
+  background:var(--ink);border:1px solid var(--hair);border-radius:8px;padding:11px 14px;
+}
+.spec-list{
+  list-style:none;margin-top:16px;font-family:var(--data);font-size:.82rem;color:var(--text-2);
+}
+.spec-list li{padding:8px 0;border-top:1px solid var(--hair);display:flex;justify-content:space-between;gap:14px}
+.spec-list li span:last-child{color:var(--text);text-align:right}
+
+/* ============================================================
+   FOOTER
+   ============================================================ */
+.site-footer{background:#080a10;border-top:1px solid var(--hair);padding:64px 0 40px}
+.footer-grid{display:grid;grid-template-columns:1.4fr 1fr 1fr 1fr;gap:40px}
+.footer-mission{font-size:.9rem;color:var(--text-2);margin-top:14px;max-width:38ch}
+.footer-col h4{
+  font-family:var(--data);font-size:.66rem;font-weight:700;letter-spacing:.16em;
+  text-transform:uppercase;color:var(--muted);margin-bottom:16px;
+}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:9px}
+.footer-col a{font-size:.88rem;color:var(--text-2);text-decoration:none}
+.footer-col a:hover{color:var(--text)}
+.footer-bottom{
+  margin-top:52px;padding-top:22px;border-top:1px solid var(--hair);
+  display:flex;justify-content:space-between;gap:14px;flex-wrap:wrap;
+  font-family:var(--data);font-size:.74rem;color:var(--muted);
+}
+.footer-bottom a{color:var(--text-2)}
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width:1020px){
+  .embed-grid{grid-template-columns:1fr}
+  .resource-grid,.terms-grid{grid-template-columns:1fr}
+  .footer-grid{grid-template-columns:1fr 1fr}
+}
+@media (max-width:820px){
+  .main-nav{display:none}
+  .data-hero .hero-inner{padding:56px 0}
+}
+@media (max-width:600px){
+  .footer-grid{grid-template-columns:1fr}
+  .section{padding:60px 0}
+}
+
+/* ============================================================
+   REDUCED MOTION
+   ============================================================ */
+@media (prefers-reduced-motion:reduce){
+  html{scroll-behavior:auto}
+}
+</style>
+</head>
+<body>
+
+<!-- ============================================================
+     HEADER
+     ============================================================ -->
+<header class="site-header">
+  <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+  <div class="header-inner">
+    <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+    <nav class="main-nav" aria-label="Primary">
+      <a class="live-link" href="air.html">Air</a>
+      <a href="water.html">Water</a>
+      <a href="sound.html">Sound</a>
+      <a href="radiation.html">Radiation</a>
+      <a href="data.html" aria-current="page">Data</a>
+      <a href="stories.html">Stories</a>
+      <a href="about.html">About</a>
+    </nav>
+    <a class="nav-cta" href="get-started.html">Get a sensor</a>
+  </div>
+</header>
+
+<main>
+
+<!-- ============================================================
+     HERO — open data hub
+     ============================================================ -->
+<section class="data-hero">
+  <div class="wrap hero-inner">
+    <p class="kicker">Data &middot; open by default</p>
+    <h1>Open data. <em>Take it, use it, publish with it.</em></h1>
+    <p class="standfirst">
+      sensors.AFRICA publishes open, real-time and historical air-quality data —
+      PM<sub>2.5</sub> and PM<sub>10</sub> particulate readings in µg/m³ — for African cities.
+      Journalists chase leads with it, researchers model with it, and civic watchdogs hold
+      polluters and policymakers to account with it. Everything on this page is free to use:
+      live widgets you can embed anywhere, a public API, and downloadable archives.
+    </p>
+    <div class="hero-facts" aria-label="What the open data covers">
+      <div class="fact"><strong>PM2.5 / PM10</strong>particulates, µg/m³</div>
+      <div class="fact"><strong>Real-time</strong>live sensor readings</div>
+      <div class="fact"><strong>Historical</strong>downloadable archives</div>
+      <div class="fact"><strong>Open</strong>free to reuse, with credit</div>
+    </div>
+    <p class="hero-credit">Air-quality data credited to the <strong>WHO Global Platform on Air Quality &amp; Health</strong>.</p>
+    <span class="proto-badge">Prototype &middot; illustrative previews</span>
+  </div>
+</section>
+
+<!-- ============================================================
+     EMBEDDABLE WIDGETS
+     ============================================================ -->
+<section class="section" id="embeds">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">Embeddable widgets</p>
+        <h2 class="display">Put live air quality on your own site</h2>
+      </div>
+      <p class="lede">Anyone — a newsroom, a school, a blog — can embed our live map, graph or dial with one iframe. No key, no sign-up. Swap the <code style="font-family:var(--data);color:var(--aqi-moderate)">city</code> parameter for your own.</p>
+    </div>
+
+    <div class="embed-grid">
+      <!-- MAP widget -->
+      <article class="embed-card">
+        <span class="accent" style="background:var(--aqi-good)" aria-hidden="true"></span>
+        <h3>Live map</h3>
+        <p>An interactive city map with every sensor node coloured by its current health band.</p>
+        <div class="embed-preview" aria-hidden="true">
+          <svg viewBox="0 0 320 130" role="img" aria-label="Stylised preview of the embeddable map widget">
+            <rect width="320" height="130" fill="#10141d"></rect>
+            <g stroke="rgba(255,255,255,0.07)" stroke-width="1">
+              <path d="M0,40 L320,52" fill="none"></path><path d="M0,86 L320,74" fill="none"></path>
+              <path d="M70,0 L84,130" fill="none"></path><path d="M180,0 L170,130" fill="none"></path><path d="M256,0 L266,130" fill="none"></path>
+            </g>
+            <circle cx="96" cy="58" r="7" fill="var(--aqi-sensitive)" stroke="#0c0f16" stroke-width="2"></circle>
+            <circle cx="150" cy="84" r="7" fill="var(--aqi-moderate)" stroke="#0c0f16" stroke-width="2"></circle>
+            <circle cx="205" cy="46" r="7" fill="var(--aqi-good)" stroke="#0c0f16" stroke-width="2"></circle>
+            <circle cx="243" cy="92" r="7" fill="var(--aqi-unhealthy)" stroke="#0c0f16" stroke-width="2"></circle>
+            <circle cx="62" cy="100" r="7" fill="var(--aqi-good)" stroke="#0c0f16" stroke-width="2"></circle>
+          </svg>
+        </div>
+        <div class="snippet">
+          <div class="snippet-label">Widget URL</div>
+          <pre><code id="map-url"><span class="u">https://sensors.africa/embeded/air/map</span>?city=<span class="t">nairobi</span></code></pre>
+          <button class="copy-btn" type="button" data-copy="map-url">Copy</button>
+        </div>
+        <div class="snippet">
+          <div class="snippet-label">Iframe snippet</div>
+          <pre><code id="map-iframe">&lt;iframe
+  src="<span class="u">https://sensors.africa/embeded/air/map?city=nairobi</span>"
+  width="100%" height="400"
+  frameborder="0" title="sensors.AFRICA air quality map — Nairobi"&gt;
+&lt;/iframe&gt;</code></pre>
+          <button class="copy-btn" type="button" data-copy="map-iframe">Copy</button>
+        </div>
+      </article>
+
+      <!-- GRAPH widget -->
+      <article class="embed-card">
+        <span class="accent" style="background:var(--aqi-moderate)" aria-hidden="true"></span>
+        <h3>Live graph</h3>
+        <p>A rolling PM<sub>2.5</sub>/PM<sub>10</sub> trend chart for the city, updated as readings arrive.</p>
+        <div class="embed-preview" aria-hidden="true">
+          <svg viewBox="0 0 320 130" role="img" aria-label="Stylised preview of the embeddable graph widget">
+            <rect width="320" height="130" fill="#10141d"></rect>
+            <g stroke="rgba(255,255,255,0.07)" stroke-width="1">
+              <line x1="24" y1="30" x2="300" y2="30"></line>
+              <line x1="24" y1="66" x2="300" y2="66"></line>
+              <line x1="24" y1="102" x2="300" y2="102"></line>
+            </g>
+            <path d="M24,88 C60,84 84,58 116,64 S172,96 204,86 S262,38 300,50" fill="none" stroke="var(--aqi-sensitive)" stroke-width="2" stroke-linecap="round"></path>
+            <path d="M24,102 C64,98 96,80 128,84 S188,106 220,100 S268,66 300,74" fill="none" stroke="var(--aqi-good)" stroke-width="2" stroke-linecap="round" opacity="0.75"></path>
+          </svg>
+        </div>
+        <div class="snippet">
+          <div class="snippet-label">Widget URL</div>
+          <pre><code id="graph-url"><span class="u">https://sensors.africa/embeded/air/graph</span>?city=<span class="t">nairobi</span></code></pre>
+          <button class="copy-btn" type="button" data-copy="graph-url">Copy</button>
+        </div>
+        <div class="snippet">
+          <div class="snippet-label">Iframe snippet</div>
+          <pre><code id="graph-iframe">&lt;iframe
+  src="<span class="u">https://sensors.africa/embeded/air/graph?city=nairobi</span>"
+  width="100%" height="340"
+  frameborder="0" title="sensors.AFRICA air quality graph — Nairobi"&gt;
+&lt;/iframe&gt;</code></pre>
+          <button class="copy-btn" type="button" data-copy="graph-iframe">Copy</button>
+        </div>
+      </article>
+
+      <!-- DIAL widget -->
+      <article class="embed-card">
+        <span class="accent" style="background:var(--aqi-sensitive)" aria-hidden="true"></span>
+        <h3>Live dial</h3>
+        <p>A compact at-a-glance gauge showing the city's current reading on the health scale.</p>
+        <div class="embed-preview" aria-hidden="true">
+          <svg viewBox="0 0 320 130" role="img" aria-label="Stylised preview of the embeddable dial widget">
+            <rect width="320" height="130" fill="#10141d"></rect>
+            <path d="M100,104 A62,62 0 0 1 128,53" fill="none" stroke="var(--aqi-good)" stroke-width="9" stroke-linecap="round"></path>
+            <path d="M136,49 A62,62 0 0 1 184,49" fill="none" stroke="var(--aqi-moderate)" stroke-width="9" stroke-linecap="round"></path>
+            <path d="M192,53 A62,62 0 0 1 220,104" fill="none" stroke="var(--aqi-sensitive)" stroke-width="9" stroke-linecap="round"></path>
+            <line x1="160" y1="104" x2="196" y2="66" stroke="#e9ebf0" stroke-width="3" stroke-linecap="round"></line>
+            <circle cx="160" cy="104" r="5" fill="#e9ebf0"></circle>
+            <text x="160" y="124" text-anchor="middle" font-size="12" font-weight="700" fill="#e9ebf0" font-family="Space Grotesk, sans-serif">38.4 µg/m³</text>
+          </svg>
+        </div>
+        <div class="snippet">
+          <div class="snippet-label">Widget URL</div>
+          <pre><code id="dial-url"><span class="u">https://sensors.africa/embeded/air/dial</span>?city=<span class="t">nairobi</span></code></pre>
+          <button class="copy-btn" type="button" data-copy="dial-url">Copy</button>
+        </div>
+        <div class="snippet">
+          <div class="snippet-label">Iframe snippet</div>
+          <pre><code id="dial-iframe">&lt;iframe
+  src="<span class="u">https://sensors.africa/embeded/air/dial?city=nairobi</span>"
+  width="300" height="250"
+  frameborder="0" title="sensors.AFRICA air quality dial — Nairobi"&gt;
+&lt;/iframe&gt;</code></pre>
+          <button class="copy-btn" type="button" data-copy="dial-iframe">Copy</button>
+        </div>
+      </article>
+    </div>
+
+    <p class="embed-note">
+      Replace <code>city=nairobi</code> with any monitored city — e.g. <code>lagos</code>,
+      <code>accra</code>, <code>dar-es-salaam</code> — to embed its live view. Widgets are served
+      from sensors.africa and update automatically; previews above are illustrative.
+    </p>
+  </div>
+</section>
+
+<!-- ============================================================
+     API + ARCHIVES — paper band
+     ============================================================ -->
+<section class="section paper-section" id="api">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">For developers &amp; researchers</p>
+        <h2 class="display">The API and the archives</h2>
+      </div>
+      <p class="lede">Widgets are the front door. Behind them sit a public API for live queries and bulk archives for serious analysis.</p>
+    </div>
+
+    <div class="resource-grid">
+      <article class="resource-card">
+        <p class="r-kicker">Public API</p>
+        <h3>Query readings, city by city</h3>
+        <p>
+          The sensors.AFRICA API serves current and recent air-quality readings by city, plus
+          pointers to historical archives — the same data behind the maps and widgets, as clean
+          JSON. Endpoints, parameters and examples are documented on the project wiki.
+        </p>
+        <ul>
+          <li>Live and recent PM<sub>2.5</sub> / PM<sub>10</sub> readings by city</li>
+          <li>Per-node sensor data across the network</li>
+          <li>Historical archives for long-run analysis</li>
+        </ul>
+        <div class="api-endpoint"><b>GET</b> https://api.sensors.africa/v2/data/  <b>·</b>  see wiki for full reference</div>
+        <div class="resource-links">
+          <a class="solid" href="https://github.com/CodeForAfrica/sensors.AFRICA/wiki/APIs" rel="noopener">API documentation →</a>
+        </div>
+      </article>
+
+      <article class="resource-card">
+        <p class="r-kicker">Archives &amp; source</p>
+        <h3>Download the raw record</h3>
+        <p>
+          Need more than a live snapshot? Historical sensor readings are archived and linked from
+          the project wiki for bulk download, and the entire platform — API, frontend and sensor
+          firmware ecosystem — is developed in the open on GitHub. File issues, read the code,
+          or fork it for your own network.
+        </p>
+        <ul>
+          <li>Historical data archives, linked from the wiki</li>
+          <li>Open-source platform code and issue tracker</li>
+          <li>Wiki guides for working with the data</li>
+        </ul>
+        <div class="resource-links">
+          <a class="solid" href="https://github.com/CodeForAfrica/sensors.AFRICA/wiki" rel="noopener">Wiki &amp; archives →</a>
+          <a href="https://github.com/CodeForAfrica/sensors.AFRICA" rel="noopener">GitHub repository →</a>
+        </div>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     LICENCE + PROVENANCE
+     ============================================================ -->
+<section class="section" id="use">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">Using the data</p>
+        <h2 class="display">Credit it, and it's yours</h2>
+      </div>
+      <p class="lede">An open project should be easy to reuse responsibly. Here's how to attribute the data — and how it's produced in the first place.</p>
+    </div>
+
+    <div class="terms-grid">
+      <article class="term-card">
+        <span class="accent" style="background:var(--aqi-good)" aria-hidden="true"></span>
+        <h3>Attribution &amp; licence</h3>
+        <p>
+          sensors.AFRICA is an open project incubated by
+          <a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a>. The data is
+          published openly for journalists, researchers and civic watchdogs to reuse — we ask
+          only that you credit the source. The platform software is free and open source,
+          released under the <a href="https://github.com/CodeForAfrica/sensors.AFRICA/blob/master/LICENSE" rel="noopener">GNU GPL v3.0</a>.
+        </p>
+        <p class="attr-line">Suggested credit: &ldquo;Air-quality data: sensors.AFRICA, a Code for Africa project &middot; WHO Global Platform on Air Quality &amp; Health.&rdquo;</p>
+      </article>
+
+      <article class="term-card">
+        <span class="accent" style="background:var(--aqi-sensitive)" aria-hidden="true"></span>
+        <h3>How the data is produced</h3>
+        <p>
+          Readings come from low-cost, open-source sensors built on
+          <a href="https://luftdaten.info/" rel="noopener">Luftdaten</a> technology around the
+          SDS011 particulate sensor. Citizens host them at homes, schools and offices; each node
+          measures the air and streams its readings to the open platform over WiFi or GSM.
+        </p>
+        <ul class="spec-list">
+          <li><span>Sensor</span><span>SDS011 (open-source Luftdaten design)</span></li>
+          <li><span>Measures</span><span>PM<sub>2.5</sub> &amp; PM<sub>10</sub>, µg/m³</span></li>
+          <li><span>Connectivity</span><span>WiFi or GSM</span></li>
+          <li><span>Hosted by</span><span>Citizens — homes, schools, offices</span></li>
+        </ul>
+      </article>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     CTA
+     ============================================================ -->
+<section class="cta-section">
+  <div class="cta-inner">
+    <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <h2>The best dataset is the one you help build.</h2>
+    <p>Host a sensor and your street becomes a data point — open, live and citable. Or just take the data above and put it to work.</p>
+    <a class="btn btn-primary" href="get-started.html">Get started — join the network</a>
+    <div><span class="proto-badge">Prototype &middot; illustrative previews; embed &amp; API links are real</span></div>
+  </div>
+</section>
+
+</main>
+
+<!-- ============================================================
+     FOOTER
+     ============================================================ -->
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+        <p class="footer-mission">A pan-African citizen science initiative using sensors to monitor air, water and sound pollution — giving citizens actionable information about their cities.</p>
+      </div>
+      <div class="footer-col">
+        <h4>Network</h4>
+        <ul>
+          <li><a href="air.html">Air quality</a></li>
+          <li><a href="water.html">Water</a></li>
+          <li><a href="sound.html">Sound</a></li>
+          <li><a href="radiation.html">Radiation</a></li>
+          <li><a href="data.html">Open data</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Community</h4>
+        <ul>
+          <li><a href="stories.html">Stories</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="get-started.html">Get a sensor</a></li>
+          <li><a href="https://twitter.com/sensorsAFRICA/" rel="noopener">Twitter</a></li>
+          <li><a href="https://www.instagram.com/sensorsAFRICA/" rel="noopener">Instagram</a></li>
+          <li><a href="https://medium.com/@sensors.AFRICA" rel="noopener">Medium</a></li>
+          <li><a href="https://github.com/CodeForAfrica/sensors.AFRICA" rel="noopener">GitHub</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Partners</h4>
+        <ul>
+          <li><a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a></li>
+          <li><a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a></li>
+          <li><a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>Incubated by <a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a> · seed-funded by <a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a> · powered by <a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></span>
+      <span>Redesign prototype — all readings on this page are illustrative sample data.</span>
+    </div>
+  </div>
+</footer>
+
+<!-- ============================================================
+     SCRIPT — copy buttons (non-essential enhancement; snippets are
+     fully readable and selectable with zero JS)
+     ============================================================ -->
+<script>
+try {
+  var buttons = document.querySelectorAll('.copy-btn');
+  if (!navigator.clipboard) {
+    // No async clipboard (e.g. non-secure context): keep snippets selectable, hide buttons.
+    buttons.forEach(function (b) { b.style.display = 'none'; });
+  } else {
+    buttons.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        try {
+          var target = document.getElementById(btn.getAttribute('data-copy'));
+          if (!target) return;
+          navigator.clipboard.writeText(target.textContent).then(function () {
+            btn.textContent = 'Copied';
+            btn.classList.add('copied');
+            setTimeout(function () {
+              btn.textContent = 'Copy';
+              btn.classList.remove('copied');
+            }, 1600);
+          }).catch(function () { /* clipboard denied — snippet stays selectable */ });
+        } catch (e) { /* non-essential */ }
+      });
+    });
+  }
+} catch (err) {
+  console.warn('Copy enhancement skipped:', err && err.message);
+}
+</script>
+
+</body>
+</html>

--- a/redesign/get-started.html
+++ b/redesign/get-started.html
@@ -1,0 +1,764 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Get started — join the sensors.AFRICA network</title>
+<meta name="description" content="Host a sensor, kickstart a sensor program in your city, or champion clean air. Join the sensors.AFRICA citizen science network.">
+
+<!-- Fonts: Fraunces (display serif) · Space Grotesk (data) · Inter (body) -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Space+Grotesk:wght@400;500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+
+<style>
+/* ============================================================
+   TOKENS — shared with all subpages, do not diverge
+   ============================================================ */
+:root{
+  --ink:#0c0f16; --ink-2:#141821; --ink-3:#1a1f2b;
+  --paper:#f1eee7; --paper-ink:#17140f;
+  --text:#e9ebf0; --text-2:#9aa2b1; --muted:#6b7280;
+  --hair:rgba(255,255,255,0.09); --hair-strong:rgba(255,255,255,0.16);
+  --aqi-good:#46d17f; --aqi-moderate:#f4c542; --aqi-sensitive:#f5822e;
+  --aqi-unhealthy:#ef5350; --aqi-veryunhealthy:#b06ae0; --aqi-hazardous:#c0466c;
+  --serif:"Fraunces",Georgia,serif;
+  --sans:"Inter",system-ui,-apple-system,sans-serif;
+  --data:"Space Grotesk","Inter",system-ui,sans-serif;
+  --maxw:1200px;
+}
+
+/* ============================================================
+   BASE
+   ============================================================ */
+*{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  background:var(--ink); color:var(--text);
+  font-family:var(--sans); font-size:16px; line-height:1.6;
+  -webkit-font-smoothing:antialiased;
+}
+img{max-width:100%;display:block}
+a{color:inherit}
+:focus-visible{outline:2px solid var(--aqi-moderate);outline-offset:3px;border-radius:2px}
+::selection{background:var(--aqi-sensitive);color:var(--ink)}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
+.kicker{
+  font-family:var(--data);font-size:.75rem;font-weight:500;
+  letter-spacing:.18em;text-transform:uppercase;color:var(--text-2);
+}
+.section-head{display:flex;align-items:baseline;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-bottom:8px}
+h2.display{
+  font-family:var(--serif);font-weight:600;font-size:clamp(1.7rem,3.4vw,2.6rem);
+  line-height:1.12;letter-spacing:-.01em;margin:10px 0 14px;
+}
+.lede{color:var(--text-2);max-width:56ch}
+
+/* The AQI spine — a segmented band used as the page's structural accent */
+.aqi-spine{display:flex;height:4px;width:100%}
+.aqi-spine span{flex:1}
+.aqi-spine .s1{background:var(--aqi-good)}
+.aqi-spine .s2{background:var(--aqi-moderate)}
+.aqi-spine .s3{background:var(--aqi-sensitive)}
+.aqi-spine .s4{background:var(--aqi-unhealthy)}
+.aqi-spine .s5{background:var(--aqi-veryunhealthy)}
+.aqi-spine .s6{background:var(--aqi-hazardous)}
+.spine-sm{width:64px;height:4px;margin-bottom:14px}
+
+/* ============================================================
+   HEADER
+   ============================================================ */
+.site-header{
+  position:sticky;top:0;z-index:1000;
+  background:rgba(12,15,22,.88);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+  border-bottom:1px solid var(--hair);
+}
+.header-inner{
+  max-width:var(--maxw);margin:0 auto;padding:0 24px;
+  display:flex;align-items:center;justify-content:space-between;gap:20px;height:64px;
+}
+.wordmark{
+  font-family:var(--data);font-weight:700;font-size:1.05rem;letter-spacing:.01em;
+  text-decoration:none;white-space:nowrap;
+}
+.wordmark .dot-africa{color:var(--aqi-good)}
+.main-nav{display:flex;gap:2px;align-items:center;overflow-x:auto}
+.main-nav a{
+  font-family:var(--data);font-size:.82rem;font-weight:500;color:var(--text-2);
+  text-decoration:none;padding:8px 11px;border-radius:6px;white-space:nowrap;
+}
+.main-nav a:hover{color:var(--text);background:var(--ink-3)}
+.main-nav a.live-link{color:var(--text)}
+.main-nav a.live-link::before{
+  content:"";display:inline-block;width:6px;height:6px;border-radius:50%;
+  background:var(--aqi-good);margin-right:7px;vertical-align:1px;
+}
+.nav-cta{
+  font-family:var(--data);font-size:.82rem;font-weight:700;text-decoration:none;
+  color:var(--ink);background:var(--aqi-good);padding:9px 16px;border-radius:999px;white-space:nowrap;
+}
+.nav-cta:hover{background:#5fdd92}
+.nav-cta[aria-current="page"]{box-shadow:0 0 0 2px var(--ink),0 0 0 4px var(--aqi-good)}
+
+/* ============================================================
+   BUTTONS (shared with landing)
+   ============================================================ */
+.btn{
+  font-family:var(--data);font-weight:700;font-size:.92rem;text-decoration:none;
+  padding:13px 24px;border-radius:999px;display:inline-block;
+}
+.btn-primary{background:var(--aqi-good);color:var(--ink)}
+.btn-primary:hover{background:#5fdd92}
+.btn-ghost{color:var(--text);border:1px solid var(--hair-strong)}
+.btn-ghost:hover{border-color:var(--text-2)}
+.proto-badge{
+  display:inline-flex;align-items:center;gap:7px;margin-top:26px;
+  font-family:var(--data);font-size:.68rem;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--muted);border:1px solid var(--hair);border-radius:999px;padding:5px 12px;
+}
+.proto-badge::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--aqi-moderate)}
+
+/* ============================================================
+   HERO — editorial, join the network
+   ============================================================ */
+.hero{position:relative;overflow:hidden;border-bottom:1px solid var(--hair)}
+.hero::before{
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:
+    radial-gradient(52rem 30rem at 82% -12%, rgba(70,209,127,.09), transparent 60%),
+    radial-gradient(44rem 26rem at 4% 115%, rgba(245,130,46,.07), transparent 60%);
+}
+.hero-inner{position:relative;padding:84px 0 72px;max-width:820px}
+.hero h1{
+  font-family:var(--serif);font-weight:640;font-variation-settings:"opsz" 100;
+  font-size:clamp(2.5rem,5.4vw,4.3rem);line-height:1.04;letter-spacing:-.015em;
+  margin-top:16px;
+}
+.hero h1 em{font-style:italic;font-weight:520;color:var(--aqi-good)}
+.hero .standfirst{margin-top:22px;font-size:1.1rem;color:var(--text-2);max-width:54ch}
+.hero-actions{margin-top:30px;display:flex;gap:14px;flex-wrap:wrap;align-items:center}
+
+/* ============================================================
+   PATHWAYS — three editorial cards
+   ============================================================ */
+.section{padding:84px 0}
+.pathways-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:34px}
+.pathway-card{
+  position:relative;display:flex;flex-direction:column;
+  background:var(--ink-2);border:1px solid var(--hair);border-radius:14px;
+  padding:28px 26px 26px;overflow:hidden;transition:transform .2s ease,border-color .2s ease;
+}
+.pathway-card:hover{transform:translateY(-3px);border-color:var(--hair-strong)}
+.pathway-card .accent{position:absolute;top:0;left:0;right:0;height:3px}
+.pathway-num{
+  font-family:var(--data);font-size:.68rem;font-weight:700;letter-spacing:.16em;
+  text-transform:uppercase;color:var(--muted);margin-bottom:18px;
+}
+.pathway-card h3{font-family:var(--serif);font-size:1.45rem;font-weight:600;line-height:1.22;margin-bottom:12px}
+.pathway-card p{font-size:.9rem;color:var(--text-2);flex:1}
+.pathway-card .who{
+  font-family:var(--data);font-size:.72rem;color:var(--muted);
+  margin-top:16px;padding-top:14px;border-top:1px solid var(--hair);
+}
+.pathway-card .who strong{color:var(--text-2);font-weight:500}
+.pathway-actions{margin-top:18px;display:flex;gap:10px;flex-wrap:wrap;align-items:center}
+.pathway-cta{
+  font-family:var(--data);font-size:.82rem;font-weight:700;text-decoration:none;
+  color:var(--ink);background:var(--aqi-good);padding:10px 18px;border-radius:999px;white-space:nowrap;
+}
+.pathway-cta:hover{background:#5fdd92}
+.pathway-alt{
+  font-family:var(--data);font-size:.8rem;font-weight:500;text-decoration:none;
+  color:var(--text-2);padding:10px 4px;white-space:nowrap;
+}
+.pathway-alt:hover{color:var(--text)}
+.pathways-foot{margin-top:24px;font-family:var(--data);font-size:.78rem;color:var(--muted)}
+.pathways-foot a{color:var(--text-2)}
+
+/* ============================================================
+   PAPER SECTION — how hosting works (warm reading surface)
+   ============================================================ */
+.paper-section{background:var(--paper);color:var(--paper-ink)}
+.paper-section .kicker{color:#6d675c}
+.paper-section h2.display{color:var(--paper-ink)}
+.paper-section .lede{color:#4d473c}
+.steps-list{list-style:none;counter-reset:step;margin-top:38px;max-width:820px}
+.steps-list li{
+  counter-increment:step;position:relative;
+  padding:0 0 34px 76px;
+}
+.steps-list li::before{
+  content:counter(step,decimal-leading-zero);
+  position:absolute;left:0;top:-4px;
+  font-family:var(--data);font-weight:700;font-size:1.15rem;
+  width:48px;height:48px;border-radius:50%;
+  display:flex;align-items:center;justify-content:center;
+  color:var(--paper-ink);background:#fff;border:1px solid #e2ddd1;
+}
+.steps-list li::after{ /* connecting rule between steps */
+  content:"";position:absolute;left:23.5px;top:48px;bottom:8px;width:1px;background:#ddd7c9;
+}
+.steps-list li:last-child{padding-bottom:0}
+.steps-list li:last-child::after{display:none}
+.steps-list li:nth-child(1)::before{box-shadow:inset 0 -3px 0 var(--aqi-good)}
+.steps-list li:nth-child(2)::before{box-shadow:inset 0 -3px 0 var(--aqi-moderate)}
+.steps-list li:nth-child(3)::before{box-shadow:inset 0 -3px 0 var(--aqi-sensitive)}
+.steps-list li:nth-child(4)::before{box-shadow:inset 0 -3px 0 var(--aqi-unhealthy)}
+.steps-list h3{font-family:var(--serif);font-size:1.4rem;font-weight:600;margin-bottom:8px}
+.steps-list p{font-family:var(--serif);font-size:1.08rem;line-height:1.68;color:#2c2820;font-weight:420;max-width:60ch}
+.steps-list .step-note{
+  display:block;margin-top:10px;font-family:var(--data);font-size:.76rem;color:#8a8375;
+}
+.steps-list .step-note a{color:#4d473c}
+
+/* ============================================================
+   HARDWARE — spec / parts list
+   ============================================================ */
+.hardware-grid{display:grid;grid-template-columns:minmax(0,.9fr) minmax(0,1.1fr);gap:48px;align-items:start;margin-top:34px}
+.hardware-prose p{color:var(--text-2);font-size:.98rem}
+.hardware-prose p+p{margin-top:1em}
+.hardware-prose strong{color:var(--text);font-weight:600}
+.hardware-badges{margin-top:22px;display:flex;gap:10px;flex-wrap:wrap}
+.hw-badge{
+  font-family:var(--data);font-size:.68rem;font-weight:700;letter-spacing:.12em;text-transform:uppercase;
+  color:var(--text-2);border:1px solid var(--hair-strong);border-radius:999px;padding:6px 14px;
+}
+.parts-card{
+  background:var(--ink-2);border:1px solid var(--hair);border-radius:16px;overflow:hidden;
+}
+.parts-card .parts-head{
+  display:flex;justify-content:space-between;align-items:baseline;gap:10px;flex-wrap:wrap;
+  padding:20px 24px 16px;border-bottom:1px solid var(--hair);
+}
+.parts-card .parts-head h3{font-family:var(--serif);font-size:1.2rem;font-weight:600}
+.parts-card .parts-head .sub{font-family:var(--data);font-size:.72rem;color:var(--muted)}
+.parts-list{list-style:none}
+.part{
+  display:grid;grid-template-columns:auto 1fr auto;gap:6px 16px;align-items:baseline;
+  padding:18px 24px;border-bottom:1px solid var(--hair);
+}
+.part:last-child{border-bottom:none}
+.part .part-id{
+  font-family:var(--data);font-weight:700;font-size:.95rem;color:var(--text);white-space:nowrap;
+}
+.part .part-id::before{
+  content:"";display:inline-block;width:8px;height:8px;border-radius:2px;
+  margin-right:10px;vertical-align:1px;background:var(--dot,var(--aqi-good));
+}
+.part .part-role{
+  grid-column:2;font-size:.86rem;color:var(--text-2);
+}
+.part .part-tag{
+  font-family:var(--data);font-size:.64rem;font-weight:700;letter-spacing:.12em;text-transform:uppercase;
+  color:var(--muted);white-space:nowrap;justify-self:end;
+}
+.parts-foot{
+  padding:16px 24px;font-family:var(--data);font-size:.72rem;color:var(--muted);
+  background:var(--ink-3);
+}
+.parts-foot a{color:var(--text-2)}
+
+/* ============================================================
+   FAQ
+   ============================================================ */
+.faq-section{background:var(--ink-2);border-top:1px solid var(--hair);border-bottom:1px solid var(--hair)}
+.faq-list{margin-top:30px;max-width:860px}
+.faq-item{border:1px solid var(--hair);border-radius:12px;background:var(--ink);margin-bottom:12px;overflow:hidden}
+.faq-item summary{
+  cursor:pointer;list-style:none;display:flex;justify-content:space-between;align-items:center;gap:16px;
+  padding:18px 22px;font-family:var(--serif);font-size:1.08rem;font-weight:600;
+}
+.faq-item summary::-webkit-details-marker{display:none}
+.faq-item summary::after{
+  content:"+";font-family:var(--data);font-weight:500;font-size:1.3rem;color:var(--muted);
+  flex:none;line-height:1;transition:transform .2s ease;
+}
+.faq-item[open] summary::after{transform:rotate(45deg);color:var(--text-2)}
+.faq-item summary:hover{background:var(--ink-3)}
+.faq-item .faq-a{padding:0 22px 20px;font-size:.92rem;color:var(--text-2);max-width:68ch}
+.faq-item .faq-a a{color:var(--text)}
+.faq-item .faq-a p+p{margin-top:.8em}
+
+/* ============================================================
+   CTA
+   ============================================================ */
+.cta-section{position:relative;overflow:hidden;border-top:1px solid var(--hair)}
+.cta-section::before{
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:radial-gradient(50rem 26rem at 50% 120%, rgba(70,209,127,.1), transparent 65%);
+}
+.cta-inner{position:relative;text-align:center;padding:96px 24px;max-width:760px;margin:0 auto}
+.cta-inner h2{
+  font-family:var(--serif);font-weight:640;font-size:clamp(2rem,4.4vw,3.3rem);
+  line-height:1.08;letter-spacing:-.015em;
+}
+.cta-inner p{margin:20px auto 32px;color:var(--text-2);max-width:46ch}
+.cta-inner .aqi-spine{width:120px;margin:0 auto 28px}
+.cta-small{margin-top:18px;font-family:var(--data);font-size:.76rem;color:var(--muted)}
+.cta-small a{color:var(--text-2)}
+
+/* ============================================================
+   FOOTER
+   ============================================================ */
+.site-footer{background:#080a10;border-top:1px solid var(--hair);padding:64px 0 40px}
+.footer-grid{display:grid;grid-template-columns:1.4fr 1fr 1fr 1fr;gap:40px}
+.footer-mission{font-size:.9rem;color:var(--text-2);margin-top:14px;max-width:38ch}
+.footer-col h4{
+  font-family:var(--data);font-size:.66rem;font-weight:700;letter-spacing:.16em;
+  text-transform:uppercase;color:var(--muted);margin-bottom:16px;
+}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:9px}
+.footer-col a{font-size:.88rem;color:var(--text-2);text-decoration:none}
+.footer-col a:hover{color:var(--text)}
+.footer-bottom{
+  margin-top:52px;padding-top:22px;border-top:1px solid var(--hair);
+  display:flex;justify-content:space-between;gap:14px;flex-wrap:wrap;
+  font-family:var(--data);font-size:.74rem;color:var(--muted);
+}
+.footer-bottom a{color:var(--text-2)}
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width:1020px){
+  .pathways-grid{grid-template-columns:1fr}
+  .hardware-grid{grid-template-columns:1fr;gap:32px}
+  .footer-grid{grid-template-columns:1fr 1fr}
+}
+@media (max-width:820px){
+  .main-nav{display:none}
+  .hero-inner{padding:60px 0 56px}
+}
+@media (max-width:600px){
+  .footer-grid{grid-template-columns:1fr}
+  .section{padding:60px 0}
+  .steps-list li{padding-left:62px}
+  .steps-list li::before{width:42px;height:42px;font-size:1rem}
+  .steps-list li::after{left:20.5px;top:42px}
+  .part{grid-template-columns:1fr;gap:4px}
+  .part .part-role{grid-column:1}
+  .part .part-tag{justify-self:start}
+}
+
+/* ============================================================
+   REDUCED MOTION
+   ============================================================ */
+@media (prefers-reduced-motion:reduce){
+  html{scroll-behavior:auto}
+  .pathway-card,.faq-item summary::after{transition:none}
+  .pathway-card:hover{transform:none}
+}
+</style>
+</head>
+<body>
+
+<!-- ============================================================
+     HEADER
+     ============================================================ -->
+<header class="site-header">
+  <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+  <div class="header-inner">
+    <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+    <nav class="main-nav" aria-label="Primary">
+      <a class="live-link" href="air.html">Air</a>
+      <a href="water.html">Water</a>
+      <a href="sound.html">Sound</a>
+      <a href="radiation.html">Radiation</a>
+      <a href="data.html">Data</a>
+      <a href="stories.html">Stories</a>
+      <a href="about.html">About</a>
+    </nav>
+    <a class="nav-cta" href="get-started.html" aria-current="page">Get a sensor</a>
+  </div>
+</header>
+
+<main>
+
+<!-- ============================================================
+     HERO — join the network
+     ============================================================ -->
+<section class="hero">
+  <div class="wrap hero-inner">
+    <p class="kicker">Get started &middot; hosts, cities &amp; champions welcome</p>
+    <h1>Join the <em>network.</em></h1>
+    <p class="standfirst">
+      Are you interested in hosting a sensor, using our data, or championing air quality
+      in your city? There's a place for you in the network — pick your path below and
+      get started. No lab coat required.
+    </p>
+    <div class="hero-actions">
+      <a class="btn btn-primary" href="https://docs.google.com/forms/d/e/1FAIpQLSdYwUWsyj5VQggCmpVh4O92VWt6NQ-J6kX-jN7uAa1FOELq0w/viewform" rel="noopener">Apply to join</a>
+      <a class="btn btn-ghost" href="#how-it-works">How hosting works</a>
+    </div>
+    <span class="proto-badge">Prototype &middot; redesign concept</span>
+  </div>
+</section>
+
+<!-- ============================================================
+     THREE PATHWAYS
+     ============================================================ -->
+<section class="section" id="pathways">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">Three ways in</p>
+        <h2 class="display">Pick your path</h2>
+      </div>
+      <p class="lede">Whether you have a window ledge, a city budget or just a loud voice — every path ends with cleaner, better-documented air.</p>
+    </div>
+
+    <div class="pathways-grid">
+      <article class="pathway-card">
+        <span class="accent" style="background:var(--aqi-good)" aria-hidden="true"></span>
+        <p class="pathway-num">Path 01 &middot; Host</p>
+        <h3>Support an existing sensor network</h3>
+        <p>
+          Already in one of our network cities? Host a sensor at your home, school or office
+          and add your street to the map. We'll help you get the kit up, connected and
+          reporting — your readings become open data the whole city can use.
+        </p>
+        <p class="who"><strong>Good for:</strong> residents, schools, newsrooms, community groups</p>
+        <div class="pathway-actions">
+          <a class="pathway-cta" href="https://docs.google.com/forms/d/e/1FAIpQLSdYwUWsyj5VQggCmpVh4O92VWt6NQ-J6kX-jN7uAa1FOELq0w/viewform" rel="noopener">Apply to host →</a>
+        </div>
+      </article>
+
+      <article class="pathway-card">
+        <span class="accent" style="background:var(--aqi-moderate)" aria-hidden="true"></span>
+        <p class="pathway-num">Path 02 &middot; Kickstart</p>
+        <h3>Kickstart your city's own sensor program</h3>
+        <p>
+          No sensors near you yet? Be the reason that changes. We work with local partners —
+          civic groups, universities, city governments, media houses — to seed new deployments,
+          train hosts and stand up a monitoring network from scratch.
+        </p>
+        <p class="who"><strong>Good for:</strong> civic organisations, universities, local government, funders</p>
+        <div class="pathway-actions">
+          <a class="pathway-cta" href="https://docs.google.com/forms/d/e/1FAIpQLSdYwUWsyj5VQggCmpVh4O92VWt6NQ-J6kX-jN7uAa1FOELq0w/viewform" rel="noopener">Start the conversation →</a>
+        </div>
+      </article>
+
+      <article class="pathway-card">
+        <span class="accent" style="background:var(--aqi-sensitive)" aria-hidden="true"></span>
+        <p class="pathway-num">Path 03 &middot; Champion</p>
+        <h3>Champion clean air</h3>
+        <p>
+          Can't host a device? Advocacy moves the needle too. Use our open data in your
+          reporting, research and campaigns, push your representatives to act on the evidence,
+          and help the readings travel further than the sensors ever could.
+        </p>
+        <p class="who"><strong>Good for:</strong> journalists, researchers, activists, everyone with a feed</p>
+        <div class="pathway-actions">
+          <a class="pathway-cta" href="https://docs.google.com/forms/d/e/1FAIpQLSdYwUWsyj5VQggCmpVh4O92VWt6NQ-J6kX-jN7uAa1FOELq0w/viewform" rel="noopener">Get involved →</a>
+          <a class="pathway-alt" href="https://twitter.com/sensorsAFRICA/" rel="noopener">Follow &amp; share on Twitter ↗</a>
+        </div>
+      </article>
+    </div>
+    <p class="pathways-foot">All three paths start with the same short form — tell us who you are and we'll route you to the right team.</p>
+  </div>
+</section>
+
+<!-- ============================================================
+     HOW HOSTING WORKS — warm paper reading surface
+     ============================================================ -->
+<section class="section paper-section" id="how-it-works">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <p class="kicker">From application to open data</p>
+    <h2 class="display">How hosting a sensor works</h2>
+    <p class="lede">Four steps, most of them ours. Your part takes an afternoon; the sensor does the rest around the clock.</p>
+
+    <ol class="steps-list">
+      <li>
+        <h3>Apply</h3>
+        <p>
+          Fill in the short interest form — where you are, where the sensor could live, and
+          whether you have Wi-Fi or would need a GSM (SIM-card) unit. We prioritise locations
+          that fill gaps in the map: near schools, clinics, industry, busy roads.
+        </p>
+        <span class="step-note">Takes about five minutes. <a href="https://docs.google.com/forms/d/e/1FAIpQLSdYwUWsyj5VQggCmpVh4O92VWt6NQ-J6kX-jN7uAa1FOELq0w/viewform" rel="noopener">Open the form</a>.</span>
+      </li>
+      <li>
+        <h3>Receive &amp; assemble the kit</h3>
+        <p>
+          Your kit arrives as a handful of off-the-shelf parts built to the open-source
+          Luftdaten design — a dust sensor, a climate sensor, a small microcontroller and a
+          weatherproof housing. Assembly is a no-solder job with step-by-step instructions,
+          and in many cities a local workshop will build it with you.
+        </p>
+      </li>
+      <li>
+        <h3>Mount it &amp; connect</h3>
+        <p>
+          Fix the unit outside — a window ledge, balcony rail or wall, away from direct rain
+          and exhaust vents — then connect it to your Wi-Fi, or use the GSM version where
+          network coverage is patchy. Once it's online it needs almost nothing from you:
+          just power and air.
+        </p>
+      </li>
+      <li>
+        <h3>Your data goes live</h3>
+        <p>
+          Within minutes your readings start streaming to the open sensors.AFRICA platform —
+          plotted on the live map, stored in the public archive, and free for journalists,
+          researchers and your own neighbours to interrogate. Your street is now on the record.
+        </p>
+        <span class="step-note">See it in action on the <a href="air.html">air quality map</a> and in the <a href="data.html">open data archive</a>.</span>
+      </li>
+    </ol>
+  </div>
+</section>
+
+<!-- ============================================================
+     THE HARDWARE — spec / parts list
+     ============================================================ -->
+<section class="section" id="hardware">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">The hardware</p>
+        <h2 class="display">A lab's worth of measurement, a phone's worth of parts</h2>
+      </div>
+    </div>
+
+    <div class="hardware-grid">
+      <div class="hardware-prose">
+        <p>
+          The sensors.AFRICA air kit is a <strong>low-cost, modular device</strong> built on the
+          open-source <strong>Luftdaten</strong> design that powers thousands of citizen sensors
+          worldwide. Every component is off-the-shelf and replaceable — if a part fails, you swap
+          it, not the whole unit.
+        </p>
+        <p>
+          That modularity is the point: the kit is <strong>cheap enough for a household,
+          durable enough for a rooftop, and accurate enough for a newsroom</strong>. It measures
+          the particulate matter that matters most to health — PM<sub>2.5</sub> and
+          PM<sub>10</sub> — alongside the temperature and humidity needed to keep those readings honest.
+        </p>
+        <p>
+          Connectivity is flexible by design. Where Wi-Fi is reliable, the standard unit uses it.
+          Where it isn't, a <strong>GSM variant</strong> reports over the mobile network instead —
+          so coverage gaps in the internet don't become coverage gaps in the data.
+        </p>
+        <div class="hardware-badges" aria-label="Kit qualities">
+          <span class="hw-badge">Open source</span>
+          <span class="hw-badge">Off-the-shelf</span>
+          <span class="hw-badge">Modular</span>
+          <span class="hw-badge">Low cost</span>
+          <span class="hw-badge">Durable</span>
+        </div>
+      </div>
+
+      <div class="parts-card">
+        <div class="parts-head">
+          <h3>What's in the kit</h3>
+          <span class="sub">Standard air-quality build &middot; Luftdaten design</span>
+        </div>
+        <ul class="parts-list">
+          <li class="part" style="--dot:var(--aqi-sensitive)">
+            <span class="part-id">SDS011</span>
+            <span class="part-tag">Dust sensor</span>
+            <span class="part-role">Laser particulate sensor measuring PM<sub>2.5</sub> and PM<sub>10</sub> — the fine dust that penetrates deep into lungs and bloodstream.</span>
+          </li>
+          <li class="part" style="--dot:var(--aqi-moderate)">
+            <span class="part-id">DHT22</span>
+            <span class="part-tag">Climate sensor</span>
+            <span class="part-role">Temperature and relative-humidity sensor — context that keeps particulate readings comparable across seasons and cities.</span>
+          </li>
+          <li class="part" style="--dot:var(--aqi-good)">
+            <span class="part-id">NodeMCU</span>
+            <span class="part-tag">Microcontroller</span>
+            <span class="part-role">The small ESP8266-based board that runs the open firmware, reads the sensors and ships the data to the platform.</span>
+          </li>
+          <li class="part" style="--dot:var(--aqi-veryunhealthy)">
+            <span class="part-id">Wi-Fi / SIM800L</span>
+            <span class="part-tag">Connectivity</span>
+            <span class="part-role">Built-in Wi-Fi as standard; a SIM800L GSM module where mobile networks are more dependable than broadband.</span>
+          </li>
+          <li class="part" style="--dot:var(--aqi-unhealthy)">
+            <span class="part-id">Housing &amp; cabling</span>
+            <span class="part-tag">Enclosure</span>
+            <span class="part-role">Weatherproof piping enclosure, tubing and USB power — simple parts from any hardware store, built to survive sun and storm.</span>
+          </li>
+        </ul>
+        <div class="parts-foot">
+          Design and firmware are open source — inspect, build or improve them at
+          <a href="https://github.com/CodeForAfrica/sensors.AFRICA" rel="noopener">github.com/CodeForAfrica</a>
+          and <a href="https://luftdaten.info/" rel="noopener">luftdaten.info</a>.
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     FAQ
+     ============================================================ -->
+<section class="section faq-section" id="faq">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">Before you ask</p>
+        <h2 class="display">Honest answers, short form</h2>
+      </div>
+    </div>
+
+    <div class="faq-list">
+      <details class="faq-item">
+        <summary>Do I need technical skills to host a sensor?</summary>
+        <div class="faq-a">
+          <p>
+            No. If you can plug in a phone charger and join a Wi-Fi network, you can host a
+            sensor. Assembly needs no soldering, and in many network cities we run build
+            workshops or deliver pre-assembled units.
+          </p>
+        </div>
+      </details>
+      <details class="faq-item">
+        <summary>What does it cost?</summary>
+        <div class="faq-a">
+          <p>
+            The kit is deliberately built from low-cost, off-the-shelf parts — a fraction of the
+            price of a reference monitoring station. Costs vary by city and program: some
+            deployments are grant-funded and free to hosts, others ask hosts or partners to
+            cover the hardware. Tell us your situation in the form and we'll be straight with
+            you about what's possible.
+          </p>
+        </div>
+      </details>
+      <details class="faq-item">
+        <summary>What if I don't have reliable Wi-Fi?</summary>
+        <div class="faq-a">
+          <p>
+            That's exactly why the GSM variant exists. Units fitted with a SIM800L module report
+            over the mobile network instead, so a sensor can live anywhere with phone signal and
+            power — no broadband required.
+          </p>
+        </div>
+      </details>
+      <details class="faq-item">
+        <summary>Is a low-cost sensor actually accurate?</summary>
+        <div class="faq-a">
+          <p>
+            Honestly: it's not a reference-grade instrument, and we don't pretend it is. What
+            the SDS011 is very good at is <em>trends and patterns</em> — rush-hour spikes, seasonal
+            shifts, block-by-block differences — across a network dense enough that no single
+            reading has to carry the story alone. That's the evidence journalists and
+            policymakers actually need, at a price cities can actually afford.
+          </p>
+        </div>
+      </details>
+      <details class="faq-item">
+        <summary>Who owns the data my sensor produces?</summary>
+        <div class="faq-a">
+          <p>
+            Everyone. Readings are published as open data — mapped live and stored in a public
+            archive that anyone can download and analyse. Your sensor's location is shown at
+            neighbourhood level on the public map.
+          </p>
+        </div>
+      </details>
+      <details class="faq-item">
+        <summary>My city isn't in the network yet. Can I still join?</summary>
+        <div class="faq-a">
+          <p>
+            Yes — that's Path 02. New cities usually start with a local partner and a handful of
+            committed hosts. If that could be you, fill in the form and tell us about your city;
+            pioneering applications are the ones we're most excited to read.
+          </p>
+        </div>
+      </details>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     CTA
+     ============================================================ -->
+<section class="cta-section">
+  <div class="cta-inner">
+    <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <h2>Put your street on the record.</h2>
+    <p>One short form is all it takes to start — as a host, a city partner or a clean-air champion. We read every application.</p>
+    <a class="btn btn-primary" href="https://docs.google.com/forms/d/e/1FAIpQLSdYwUWsyj5VQggCmpVh4O92VWt6NQ-J6kX-jN7uAa1FOELq0w/viewform" rel="noopener">Apply to join the network</a>
+    <p class="cta-small">Prefer to talk first? Reach the team via <a href="https://twitter.com/sensorsAFRICA/" rel="noopener">@sensorsAFRICA</a>.</p>
+  </div>
+</section>
+
+</main>
+
+<!-- ============================================================
+     FOOTER
+     ============================================================ -->
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+        <p class="footer-mission">A pan-African citizen science initiative using sensors to monitor air, water and sound pollution — giving citizens actionable information about their cities.</p>
+      </div>
+      <div class="footer-col">
+        <h4>Network</h4>
+        <ul>
+          <li><a href="air.html">Air quality</a></li>
+          <li><a href="water.html">Water</a></li>
+          <li><a href="sound.html">Sound</a></li>
+          <li><a href="radiation.html">Radiation</a></li>
+          <li><a href="data.html">Open data</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Community</h4>
+        <ul>
+          <li><a href="stories.html">Stories</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="get-started.html">Get a sensor</a></li>
+          <li><a href="https://twitter.com/sensorsAFRICA/" rel="noopener">Twitter</a></li>
+          <li><a href="https://www.instagram.com/sensorsAFRICA/" rel="noopener">Instagram</a></li>
+          <li><a href="https://medium.com/@sensors.AFRICA" rel="noopener">Medium</a></li>
+          <li><a href="https://github.com/CodeForAfrica/sensors.AFRICA" rel="noopener">GitHub</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Partners</h4>
+        <ul>
+          <li><a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a></li>
+          <li><a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a></li>
+          <li><a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>Incubated by <a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a> · seed-funded by <a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a> · powered by <a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></span>
+      <span>Redesign prototype — all readings on this page are illustrative sample data.</span>
+    </div>
+  </div>
+</footer>
+
+<!-- ============================================================
+     SCRIPT — tiny enhancement only: close other FAQ items when one
+     opens (accordion behaviour). Content works fully without JS.
+     ============================================================ -->
+<script>
+try {
+  var items = Array.prototype.slice.call(document.querySelectorAll('.faq-item'));
+  items.forEach(function (item) {
+    item.addEventListener('toggle', function () {
+      if (item.open) {
+        items.forEach(function (other) {
+          if (other !== item && other.open) other.open = false;
+        });
+      }
+    });
+  });
+} catch (err) {
+  console.warn('FAQ enhancement skipped:', err && err.message);
+}
+</script>
+
+</body>
+</html>

--- a/redesign/index.html
+++ b/redesign/index.html
@@ -1,0 +1,1134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>sensors.AFRICA — Citizen-powered pollution data for African cities</title>
+<meta name="description" content="sensors.AFRICA is a pan-African citizen science initiative that uses sensors to monitor air, water and sound pollution to give citizens actionable information about their cities.">
+
+<!-- Fonts: Fraunces (display serif) · Space Grotesk (data) · Inter (body) -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Space+Grotesk:wght@400;500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+
+<!-- Leaflet (map) -->
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="">
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
+
+<style>
+/* ============================================================
+   TOKENS — shared with all subpages, do not diverge
+   ============================================================ */
+:root{
+  --ink:#0c0f16; --ink-2:#141821; --ink-3:#1a1f2b;
+  --paper:#f1eee7; --paper-ink:#17140f;
+  --text:#e9ebf0; --text-2:#9aa2b1; --muted:#6b7280;
+  --hair:rgba(255,255,255,0.09); --hair-strong:rgba(255,255,255,0.16);
+  --aqi-good:#46d17f; --aqi-moderate:#f4c542; --aqi-sensitive:#f5822e;
+  --aqi-unhealthy:#ef5350; --aqi-veryunhealthy:#b06ae0; --aqi-hazardous:#c0466c;
+  --serif:"Fraunces",Georgia,serif;
+  --sans:"Inter",system-ui,-apple-system,sans-serif;
+  --data:"Space Grotesk","Inter",system-ui,sans-serif;
+  --maxw:1200px;
+}
+
+/* ============================================================
+   BASE
+   ============================================================ */
+*{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  background:var(--ink); color:var(--text);
+  font-family:var(--sans); font-size:16px; line-height:1.6;
+  -webkit-font-smoothing:antialiased;
+}
+img{max-width:100%;display:block}
+a{color:inherit}
+:focus-visible{outline:2px solid var(--aqi-moderate);outline-offset:3px;border-radius:2px}
+::selection{background:var(--aqi-sensitive);color:var(--ink)}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
+.kicker{
+  font-family:var(--data);font-size:.75rem;font-weight:500;
+  letter-spacing:.18em;text-transform:uppercase;color:var(--text-2);
+}
+.section-head{display:flex;align-items:baseline;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-bottom:8px}
+h2.display{
+  font-family:var(--serif);font-weight:600;font-size:clamp(1.7rem,3.4vw,2.6rem);
+  line-height:1.12;letter-spacing:-.01em;margin:10px 0 14px;
+}
+.lede{color:var(--text-2);max-width:56ch}
+
+/* The AQI spine — a segmented band used as the page's structural accent */
+.aqi-spine{display:flex;height:4px;width:100%}
+.aqi-spine span{flex:1}
+.aqi-spine .s1{background:var(--aqi-good)}
+.aqi-spine .s2{background:var(--aqi-moderate)}
+.aqi-spine .s3{background:var(--aqi-sensitive)}
+.aqi-spine .s4{background:var(--aqi-unhealthy)}
+.aqi-spine .s5{background:var(--aqi-veryunhealthy)}
+.aqi-spine .s6{background:var(--aqi-hazardous)}
+.spine-sm{width:64px;height:4px;margin-bottom:14px}
+
+/* ============================================================
+   HEADER
+   ============================================================ */
+.site-header{
+  position:sticky;top:0;z-index:1000;
+  background:rgba(12,15,22,.88);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+  border-bottom:1px solid var(--hair);
+}
+.header-inner{
+  max-width:var(--maxw);margin:0 auto;padding:0 24px;
+  display:flex;align-items:center;justify-content:space-between;gap:20px;height:64px;
+}
+.wordmark{
+  font-family:var(--data);font-weight:700;font-size:1.05rem;letter-spacing:.01em;
+  text-decoration:none;white-space:nowrap;
+}
+.wordmark .dot-africa{color:var(--aqi-good)}
+.main-nav{display:flex;gap:2px;align-items:center;overflow-x:auto}
+.main-nav a{
+  font-family:var(--data);font-size:.82rem;font-weight:500;color:var(--text-2);
+  text-decoration:none;padding:8px 11px;border-radius:6px;white-space:nowrap;
+}
+.main-nav a:hover{color:var(--text);background:var(--ink-3)}
+.main-nav a.live-link{color:var(--text)}
+.main-nav a.live-link::before{
+  content:"";display:inline-block;width:6px;height:6px;border-radius:50%;
+  background:var(--aqi-good);margin-right:7px;vertical-align:1px;
+}
+.nav-cta{
+  font-family:var(--data);font-size:.82rem;font-weight:700;text-decoration:none;
+  color:var(--ink);background:var(--aqi-good);padding:9px 16px;border-radius:999px;white-space:nowrap;
+}
+.nav-cta:hover{background:#5fdd92}
+
+/* ============================================================
+   HERO
+   ============================================================ */
+.hero{position:relative;overflow:hidden;border-bottom:1px solid var(--hair)}
+.hero::before{ /* faint atmospheric wash */
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:
+    radial-gradient(52rem 30rem at 78% -10%, rgba(245,130,46,.09), transparent 60%),
+    radial-gradient(44rem 26rem at 8% 110%, rgba(70,209,127,.06), transparent 60%);
+}
+.hero-grid{
+  position:relative;display:grid;grid-template-columns:minmax(0,1.15fr) minmax(0,.85fr);
+  gap:56px;align-items:center;padding:76px 0 68px;
+}
+.hero h1{
+  font-family:var(--serif);font-weight:640;font-variation-settings:"opsz" 100;
+  font-size:clamp(2.5rem,5.4vw,4.3rem);line-height:1.04;letter-spacing:-.015em;
+}
+.hero h1 em{font-style:italic;font-weight:520;color:var(--aqi-sensitive)}
+.hero .standfirst{margin-top:22px;font-size:1.08rem;color:var(--text-2);max-width:52ch}
+.hero-actions{margin-top:30px;display:flex;gap:14px;flex-wrap:wrap;align-items:center}
+.btn{
+  font-family:var(--data);font-weight:700;font-size:.92rem;text-decoration:none;
+  padding:13px 24px;border-radius:999px;display:inline-block;
+}
+.btn-primary{background:var(--aqi-good);color:var(--ink)}
+.btn-primary:hover{background:#5fdd92}
+.btn-ghost{color:var(--text);border:1px solid var(--hair-strong)}
+.btn-ghost:hover{border-color:var(--text-2)}
+.proto-badge{
+  display:inline-flex;align-items:center;gap:7px;margin-top:26px;
+  font-family:var(--data);font-size:.68rem;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--muted);border:1px solid var(--hair);border-radius:999px;padding:5px 12px;
+}
+.proto-badge::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--aqi-moderate)}
+
+/* Live reading panel — the hero centerpiece */
+.reading-panel{
+  position:relative;background:var(--ink-2);border:1px solid var(--hair-strong);
+  border-radius:16px;padding:26px 28px 24px;box-shadow:0 24px 60px rgba(0,0,0,.45);
+}
+.reading-panel .panel-spine{position:absolute;top:0;left:0;right:0;border-radius:16px 16px 0 0;overflow:hidden}
+.panel-top{display:flex;justify-content:space-between;align-items:baseline;gap:12px;margin-top:6px}
+.panel-city{font-family:var(--serif);font-size:1.5rem;font-weight:600}
+.panel-live{
+  font-family:var(--data);font-size:.68rem;letter-spacing:.16em;text-transform:uppercase;color:var(--text-2);
+  display:inline-flex;align-items:center;gap:7px;
+}
+.panel-live .pulse{width:8px;height:8px;border-radius:50%;background:var(--aqi-good);animation:pulse 2.2s ease-out infinite}
+@keyframes pulse{0%{box-shadow:0 0 0 0 rgba(70,209,127,.55)}70%{box-shadow:0 0 0 9px rgba(70,209,127,0)}100%{box-shadow:0 0 0 0 rgba(70,209,127,0)}}
+.big-reading{display:flex;align-items:baseline;gap:12px;margin:14px 0 4px}
+.big-reading .num{
+  font-family:var(--data);font-weight:700;font-size:clamp(4rem,7vw,5.6rem);
+  line-height:1;letter-spacing:-.02em;color:var(--aqi-sensitive);
+}
+.big-reading .unit-block{font-family:var(--data);color:var(--text-2);font-size:.85rem;line-height:1.4}
+.band-chip{
+  display:inline-flex;align-items:center;gap:8px;margin-top:8px;
+  font-family:var(--data);font-size:.8rem;font-weight:500;color:var(--text);
+  background:var(--ink-3);border:1px solid var(--hair);border-radius:999px;padding:6px 14px;
+}
+.band-chip .swatch{width:9px;height:9px;border-radius:50%;background:var(--aqi-sensitive)}
+/* mini AQI meter: reading position on the health scale */
+.aqi-meter{margin-top:22px}
+.aqi-meter .track{position:relative;height:6px;border-radius:3px;overflow:visible;display:flex}
+.aqi-meter .track span{flex:1;opacity:.85}
+.aqi-meter .track span:first-child{border-radius:3px 0 0 3px}
+.aqi-meter .track span:last-child{border-radius:0 3px 3px 0}
+.aqi-meter .needle{
+  position:absolute;top:-4px;width:3px;height:14px;border-radius:2px;
+  background:var(--text);box-shadow:0 0 0 2px var(--ink-2);left:44%;
+}
+.aqi-meter .scale-labels{
+  display:flex;justify-content:space-between;margin-top:8px;
+  font-family:var(--data);font-size:.62rem;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);
+}
+.panel-meta{
+  margin-top:20px;padding-top:14px;border-top:1px solid var(--hair);
+  display:flex;justify-content:space-between;gap:10px;flex-wrap:wrap;
+  font-family:var(--data);font-size:.72rem;color:var(--muted);
+}
+.panel-meta strong{color:var(--text-2);font-weight:500}
+
+/* ============================================================
+   TICKER
+   ============================================================ */
+.ticker-band{border-bottom:1px solid var(--hair);background:var(--ink-2);overflow:hidden}
+.ticker-label{
+  float:left;position:relative;z-index:2;display:flex;align-items:center;gap:8px;height:46px;
+  padding:0 18px;background:var(--ink-2);border-right:1px solid var(--hair-strong);
+  font-family:var(--data);font-size:.68rem;font-weight:700;letter-spacing:.16em;text-transform:uppercase;color:var(--text-2);
+  white-space:nowrap;
+}
+.ticker-viewport{overflow:hidden;height:46px}
+.ticker-track{display:inline-flex;align-items:center;height:46px;white-space:nowrap;animation:ticker 60s linear infinite}
+.ticker-band:hover .ticker-track{animation-play-state:paused}
+@keyframes ticker{from{transform:translateX(0)}to{transform:translateX(-50%)}}
+.ticker-set{display:inline-flex;align-items:center}
+.tick{
+  display:inline-flex;align-items:baseline;gap:8px;padding:0 26px;
+  font-family:var(--data);font-size:.84rem;border-right:1px solid var(--hair);
+}
+.tick .c{color:var(--text-2)}
+.tick .dot{width:8px;height:8px;border-radius:50%;align-self:center;flex:none}
+.tick .v{font-weight:700;color:var(--text);font-variant-numeric:tabular-nums}
+.tick .b{font-size:.68rem;letter-spacing:.06em;text-transform:uppercase;color:var(--muted)}
+
+/* ============================================================
+   STREAMS (four monitoring streams)
+   ============================================================ */
+.section{padding:84px 0}
+.streams-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-top:34px}
+.stream-card{
+  position:relative;display:block;text-decoration:none;
+  background:var(--ink-2);border:1px solid var(--hair);border-radius:14px;
+  padding:26px 24px 24px;overflow:hidden;transition:transform .2s ease,border-color .2s ease;
+}
+.stream-card:hover{transform:translateY(-3px);border-color:var(--hair-strong)}
+.stream-card .accent{position:absolute;top:0;left:0;right:0;height:3px}
+.stream-card .glyph{font-size:1.6rem;line-height:1;margin-bottom:16px}
+.stream-card h3{font-family:var(--serif);font-size:1.35rem;font-weight:600;margin-bottom:8px}
+.stream-card p{font-size:.88rem;color:var(--text-2);min-height:4.2em}
+.stream-status{
+  display:inline-flex;align-items:center;gap:7px;margin-top:16px;
+  font-family:var(--data);font-size:.66rem;font-weight:700;letter-spacing:.14em;text-transform:uppercase;
+  border-radius:999px;padding:5px 12px;
+}
+.stream-status.live{color:var(--aqi-good);border:1px solid rgba(70,209,127,.4)}
+.stream-status.live::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--aqi-good)}
+.stream-status.soon{color:var(--muted);border:1px solid var(--hair)}
+.stream-card .go{
+  position:absolute;right:20px;bottom:22px;font-family:var(--data);
+  color:var(--muted);font-size:1rem;transition:transform .2s ease,color .2s ease;
+}
+.stream-card:hover .go{transform:translateX(4px);color:var(--text)}
+
+/* ============================================================
+   MAP
+   ============================================================ */
+.map-section{background:var(--ink-2);border-top:1px solid var(--hair);border-bottom:1px solid var(--hair)}
+.map-shell{
+  position:relative;margin-top:34px;border:1px solid var(--hair-strong);
+  border-radius:16px;overflow:hidden;height:540px;
+  /* graceful fallback: atmospheric gradient + faint graticule if tiles never load */
+  background:
+    linear-gradient(var(--hair) 1px,transparent 1px),
+    linear-gradient(90deg,var(--hair) 1px,transparent 1px),
+    radial-gradient(60rem 34rem at 50% 20%,#151a26,var(--ink));
+  background-size:64px 64px,64px 64px,cover;
+}
+#africa-map{position:absolute;inset:0;background:transparent}
+.leaflet-container{background:transparent;font-family:var(--sans)}
+.map-fallback-note{
+  position:absolute;inset:0;display:flex;align-items:center;justify-content:center;
+  color:var(--muted);font-family:var(--data);font-size:.85rem;text-align:center;padding:24px;
+}
+.map-legend{
+  position:absolute;z-index:800;left:16px;bottom:16px;
+  background:rgba(12,15,22,.9);border:1px solid var(--hair-strong);border-radius:12px;
+  padding:14px 16px;font-family:var(--data);font-size:.72rem;color:var(--text-2);
+  backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);
+}
+.map-legend .lg-title{font-weight:700;letter-spacing:.12em;text-transform:uppercase;font-size:.62rem;color:var(--muted);margin-bottom:9px}
+.map-legend ul{list-style:none;display:grid;grid-template-columns:1fr 1fr;gap:5px 18px}
+.map-legend li{display:flex;align-items:center;gap:8px;white-space:nowrap}
+.map-legend .sw{width:9px;height:9px;border-radius:50%;flex:none}
+.map-count{
+  position:absolute;z-index:800;right:16px;top:16px;text-align:right;
+  background:rgba(12,15,22,.9);border:1px solid var(--hair-strong);border-radius:12px;padding:12px 16px;
+  font-family:var(--data);backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);
+}
+.map-count .n{font-size:1.5rem;font-weight:700;line-height:1.1}
+.map-count .l{font-size:.64rem;letter-spacing:.12em;text-transform:uppercase;color:var(--muted)}
+.leaflet-popup-content-wrapper{background:var(--ink-3);color:var(--text);border-radius:10px;border:1px solid var(--hair-strong)}
+.leaflet-popup-tip{background:var(--ink-3)}
+.leaflet-popup-content{font-family:var(--data);font-size:.85rem;margin:12px 16px}
+.popup-city{font-weight:700;font-size:1rem}
+.popup-reading{font-variant-numeric:tabular-nums}
+.data-note{margin-top:14px;font-size:.75rem;color:var(--muted);font-family:var(--data)}
+
+/* ============================================================
+   TREND CHART
+   ============================================================ */
+.chart-card{
+  margin-top:34px;background:var(--ink-2);border:1px solid var(--hair);
+  border-radius:16px;padding:26px 22px 16px;position:relative;
+}
+.chart-card .chart-title-row{display:flex;justify-content:space-between;align-items:baseline;flex-wrap:wrap;gap:8px;padding:0 8px}
+.chart-card h3{font-family:var(--serif);font-size:1.2rem;font-weight:600}
+.chart-card .sub{font-family:var(--data);font-size:.74rem;color:var(--muted)}
+.trend-svg{width:100%;height:auto;display:block;margin-top:10px}
+.trend-svg text{font-family:var(--data)}
+.chart-tip{
+  position:absolute;pointer-events:none;display:none;z-index:5;
+  background:var(--ink);border:1px solid var(--hair-strong);border-radius:8px;
+  padding:7px 11px;font-family:var(--data);font-size:.75rem;white-space:nowrap;
+  transform:translate(-50%,-130%);box-shadow:0 8px 24px rgba(0,0,0,.5);
+}
+.chart-table{margin:6px 8px 10px}
+.chart-table summary{font-family:var(--data);font-size:.74rem;color:var(--muted);cursor:pointer}
+.chart-table summary:hover{color:var(--text-2)}
+.chart-table table{margin-top:12px;border-collapse:collapse;font-family:var(--data);font-size:.74rem;width:100%}
+.chart-table th,.chart-table td{
+  border:1px solid var(--hair);padding:4px 8px;text-align:right;
+  font-variant-numeric:tabular-nums;color:var(--text-2);
+}
+.chart-table th{color:var(--muted);font-weight:500}
+
+/* ============================================================
+   PAPER SECTION — why it matters (long-form reading surface)
+   ============================================================ */
+.paper-section{background:var(--paper);color:var(--paper-ink)}
+.paper-section .kicker{color:#6d675c}
+.paper-section h2.display{color:var(--paper-ink)}
+.paper-section .lede{color:#4d473c}
+.impact-grid{display:grid;grid-template-columns:1.1fr .9fr;gap:56px;align-items:start;margin-top:20px}
+.impact-prose{font-family:var(--serif);font-size:1.16rem;line-height:1.72;color:#2c2820;font-weight:420}
+.impact-prose p+p{margin-top:1.1em}
+.impact-prose strong{font-weight:640;color:var(--paper-ink)}
+.stat-tiles{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+.stat-tile{background:#fff;border:1px solid #e2ddd1;border-radius:12px;padding:20px 20px 18px}
+.stat-tile .val{font-family:var(--data);font-weight:700;font-size:2.1rem;line-height:1.1;color:var(--paper-ink)}
+.stat-tile .lbl{font-size:.8rem;color:#6d675c;margin-top:6px;line-height:1.45}
+.stat-tile .bar{height:4px;border-radius:2px;background:#ece8dd;margin-top:14px;overflow:hidden}
+.stat-tile .bar i{display:block;height:100%;border-radius:2px}
+.paper-credit{margin-top:34px;font-family:var(--data);font-size:.74rem;color:#8a8375}
+
+/* ============================================================
+   STORIES
+   ============================================================ */
+.stories-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:34px}
+.story-card{
+  display:flex;flex-direction:column;text-decoration:none;
+  background:var(--ink-2);border:1px solid var(--hair);border-radius:14px;overflow:hidden;
+  transition:transform .2s ease,border-color .2s ease;
+}
+.story-card:hover{transform:translateY(-3px);border-color:var(--hair-strong)}
+.story-visual{height:150px;position:relative;overflow:hidden}
+.story-visual svg{width:100%;height:100%;display:block}
+.story-body{padding:22px 22px 24px;display:flex;flex-direction:column;flex:1}
+.story-tag{font-family:var(--data);font-size:.64rem;font-weight:700;letter-spacing:.16em;text-transform:uppercase;color:var(--text-2);margin-bottom:10px}
+.story-card h3{font-family:var(--serif);font-size:1.28rem;font-weight:600;line-height:1.25;margin-bottom:10px}
+.story-card p{font-size:.88rem;color:var(--text-2);flex:1}
+.story-more{margin-top:16px;font-family:var(--data);font-size:.78rem;font-weight:700;color:var(--aqi-good)}
+.stories-foot{margin-top:26px;font-family:var(--data);font-size:.82rem;color:var(--text-2)}
+.stories-foot a{color:var(--text)}
+
+/* ============================================================
+   HOW IT WORKS
+   ============================================================ */
+.how-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:34px}
+.how-step{background:var(--ink-2);border:1px solid var(--hair);border-radius:14px;padding:26px 24px}
+.how-step .num{
+  font-family:var(--data);font-weight:700;font-size:.8rem;color:var(--ink);
+  width:30px;height:30px;border-radius:50%;display:flex;align-items:center;justify-content:center;
+  background:var(--aqi-good);margin-bottom:18px;
+}
+.how-step:nth-child(2) .num{background:var(--aqi-moderate)}
+.how-step:nth-child(3) .num{background:var(--aqi-sensitive)}
+.how-step h3{font-family:var(--serif);font-size:1.25rem;font-weight:600;margin-bottom:9px}
+.how-step p{font-size:.88rem;color:var(--text-2)}
+
+/* ============================================================
+   CTA
+   ============================================================ */
+.cta-section{position:relative;overflow:hidden;border-top:1px solid var(--hair)}
+.cta-section::before{
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:radial-gradient(50rem 26rem at 50% 120%, rgba(70,209,127,.1), transparent 65%);
+}
+.cta-inner{position:relative;text-align:center;padding:96px 24px;max-width:760px;margin:0 auto}
+.cta-inner h2{
+  font-family:var(--serif);font-weight:640;font-size:clamp(2rem,4.4vw,3.3rem);
+  line-height:1.08;letter-spacing:-.015em;
+}
+.cta-inner p{margin:20px auto 32px;color:var(--text-2);max-width:46ch}
+.cta-inner .aqi-spine{width:120px;margin:0 auto 28px}
+
+/* ============================================================
+   FOOTER
+   ============================================================ */
+.site-footer{background:#080a10;border-top:1px solid var(--hair);padding:64px 0 40px}
+.footer-grid{display:grid;grid-template-columns:1.4fr 1fr 1fr 1fr;gap:40px}
+.footer-mission{font-size:.9rem;color:var(--text-2);margin-top:14px;max-width:38ch}
+.footer-col h4{
+  font-family:var(--data);font-size:.66rem;font-weight:700;letter-spacing:.16em;
+  text-transform:uppercase;color:var(--muted);margin-bottom:16px;
+}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:9px}
+.footer-col a{font-size:.88rem;color:var(--text-2);text-decoration:none}
+.footer-col a:hover{color:var(--text)}
+.footer-bottom{
+  margin-top:52px;padding-top:22px;border-top:1px solid var(--hair);
+  display:flex;justify-content:space-between;gap:14px;flex-wrap:wrap;
+  font-family:var(--data);font-size:.74rem;color:var(--muted);
+}
+.footer-bottom a{color:var(--text-2)}
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width:1020px){
+  .streams-grid{grid-template-columns:1fr 1fr}
+  .stories-grid{grid-template-columns:1fr 1fr}
+  .footer-grid{grid-template-columns:1fr 1fr}
+  .impact-grid{grid-template-columns:1fr;gap:36px}
+}
+@media (max-width:820px){
+  .hero-grid{grid-template-columns:1fr;gap:40px;padding:56px 0}
+  .main-nav{display:none}
+  .how-grid{grid-template-columns:1fr}
+  .map-shell{height:440px}
+}
+@media (max-width:600px){
+  .streams-grid,.stories-grid,.stat-tiles,.footer-grid{grid-template-columns:1fr}
+  .section{padding:60px 0}
+  .ticker-label{display:none}
+}
+
+/* ============================================================
+   REDUCED MOTION
+   ============================================================ */
+@media (prefers-reduced-motion:reduce){
+  html{scroll-behavior:auto}
+  .ticker-track{animation:none}
+  .ticker-viewport{overflow-x:auto}
+  .panel-live .pulse{animation:none}
+  .stream-card,.story-card,.stream-card .go{transition:none}
+  .stream-card:hover,.story-card:hover{transform:none}
+}
+</style>
+</head>
+<body>
+
+<!-- ============================================================
+     HEADER
+     ============================================================ -->
+<header class="site-header">
+  <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+  <div class="header-inner">
+    <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+    <nav class="main-nav" aria-label="Primary">
+      <a class="live-link" href="air.html">Air</a>
+      <a href="water.html">Water</a>
+      <a href="sound.html">Sound</a>
+      <a href="radiation.html">Radiation</a>
+      <a href="data.html">Data</a>
+      <a href="stories.html">Stories</a>
+      <a href="about.html">About</a>
+    </nav>
+    <a class="nav-cta" href="get-started.html">Get a sensor</a>
+  </div>
+</header>
+
+<main>
+
+<!-- ============================================================
+     HERO
+     ============================================================ -->
+<section class="hero">
+  <div class="wrap hero-grid">
+    <div>
+      <p class="kicker">Citizen science &middot; 16 cities &middot; 5 countries</p>
+      <h1>The air keeps a record. <em>We publish it.</em></h1>
+      <p class="standfirst">
+        sensors.AFRICA is a pan-African citizen science initiative that uses sensors to monitor
+        air, water and sound pollution to give citizens actionable information about their cities.
+        Every reading below is testimony — hyper-local evidence for journalists, watchdogs and residents.
+      </p>
+      <div class="hero-actions">
+        <a class="btn btn-primary" href="get-started.html">Join the network</a>
+        <a class="btn btn-ghost" href="data.html">Explore the data</a>
+      </div>
+      <span class="proto-badge">Prototype &middot; illustrative data</span>
+    </div>
+
+    <!-- Live reading panel -->
+    <aside class="reading-panel" aria-label="Featured live air quality reading (sample data)">
+      <div class="panel-spine aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+      <div class="panel-top">
+        <span class="panel-city">Nairobi, Kenya</span>
+        <span class="panel-live"><span class="pulse" aria-hidden="true"></span>Live reading</span>
+      </div>
+      <div class="big-reading">
+        <span class="num" id="hero-pm25">38.4</span>
+        <span class="unit-block">µg/m³<br>PM<sub>2.5</sub></span>
+      </div>
+      <span class="band-chip"><span class="swatch" aria-hidden="true"></span>Unhealthy for sensitive groups</span>
+      <div class="aqi-meter">
+        <div class="track" aria-hidden="true">
+          <span style="background:var(--aqi-good)"></span><span style="background:var(--aqi-moderate)"></span><span style="background:var(--aqi-sensitive)"></span><span style="background:var(--aqi-unhealthy)"></span><span style="background:var(--aqi-veryunhealthy)"></span><span style="background:var(--aqi-hazardous)"></span>
+        </div>
+        <div class="needle" aria-hidden="true" style="left:42%"></div>
+        <div class="scale-labels" aria-hidden="true"><span>Good</span><span>Hazardous</span></div>
+      </div>
+      <div class="panel-meta">
+        <span>PM<sub>10</sub> <strong>51.2 µg/m³</strong></span>
+        <span>SDS011 &middot; Luftdaten network</span>
+        <span>Updated <strong id="hero-updated">just now</strong></span>
+      </div>
+    </aside>
+  </div>
+</section>
+
+<!-- ============================================================
+     TICKER — live-style readings across the network (sample data)
+     ============================================================ -->
+<div class="ticker-band" aria-label="Sample PM2.5 readings across the network">
+  <div class="ticker-label"><span class="pulse" style="width:7px;height:7px;border-radius:50%;background:var(--aqi-good)" aria-hidden="true"></span>Network &middot; PM2.5</div>
+  <div class="ticker-viewport">
+    <div class="ticker-track" id="ticker-track">
+      <div class="ticker-set">
+        <span class="tick"><span class="c">Nairobi</span><span class="dot" style="background:var(--aqi-sensitive)" aria-hidden="true"></span><span class="v">38.4</span><span class="b">Sensitive</span></span>
+        <span class="tick"><span class="c">Lagos</span><span class="dot" style="background:var(--aqi-unhealthy)" aria-hidden="true"></span><span class="v">68.2</span><span class="b">Unhealthy</span></span>
+        <span class="tick"><span class="c">Accra</span><span class="dot" style="background:var(--aqi-sensitive)" aria-hidden="true"></span><span class="v">47.3</span><span class="b">Sensitive</span></span>
+        <span class="tick"><span class="c">Dar es Salaam</span><span class="dot" style="background:var(--aqi-moderate)" aria-hidden="true"></span><span class="v">28.9</span><span class="b">Moderate</span></span>
+        <span class="tick"><span class="c">Lusaka</span><span class="dot" style="background:var(--aqi-good)" aria-hidden="true"></span><span class="v">11.2</span><span class="b">Good</span></span>
+        <span class="tick"><span class="c">Abuja</span><span class="dot" style="background:var(--aqi-sensitive)" aria-hidden="true"></span><span class="v">44.1</span><span class="b">Sensitive</span></span>
+        <span class="tick"><span class="c">Kano</span><span class="dot" style="background:var(--aqi-unhealthy)" aria-hidden="true"></span><span class="v">138.7</span><span class="b">Unhealthy</span></span>
+        <span class="tick"><span class="c">Maiduguri</span><span class="dot" style="background:var(--aqi-veryunhealthy)" aria-hidden="true"></span><span class="v">161.0</span><span class="b">Very unhealthy</span></span>
+        <span class="tick"><span class="c">Kumasi</span><span class="dot" style="background:var(--aqi-sensitive)" aria-hidden="true"></span><span class="v">35.9</span><span class="b">Sensitive</span></span>
+        <span class="tick"><span class="c">Nakuru</span><span class="dot" style="background:var(--aqi-moderate)" aria-hidden="true"></span><span class="v">21.7</span><span class="b">Moderate</span></span>
+        <span class="tick"><span class="c">Port Harcourt</span><span class="dot" style="background:var(--aqi-unhealthy)" aria-hidden="true"></span><span class="v">74.5</span><span class="b">Unhealthy</span></span>
+        <span class="tick"><span class="c">Kisumu</span><span class="dot" style="background:var(--aqi-moderate)" aria-hidden="true"></span><span class="v">17.3</span><span class="b">Moderate</span></span>
+        <span class="tick"><span class="c">Ilorin</span><span class="dot" style="background:var(--aqi-sensitive)" aria-hidden="true"></span><span class="v">52.6</span><span class="b">Sensitive</span></span>
+        <span class="tick"><span class="c">Awka</span><span class="dot" style="background:var(--aqi-sensitive)" aria-hidden="true"></span><span class="v">41.9</span><span class="b">Sensitive</span></span>
+        <span class="tick"><span class="c">Akure</span><span class="dot" style="background:var(--aqi-moderate)" aria-hidden="true"></span><span class="v">33.5</span><span class="b">Moderate</span></span>
+        <span class="tick"><span class="c">Ado-Ekiti</span><span class="dot" style="background:var(--aqi-moderate)" aria-hidden="true"></span><span class="v">29.8</span><span class="b">Moderate</span></span>
+      </div>
+      <div class="ticker-set" aria-hidden="true">
+        <span class="tick"><span class="c">Nairobi</span><span class="dot" style="background:var(--aqi-sensitive)"></span><span class="v">38.4</span><span class="b">Sensitive</span></span>
+        <span class="tick"><span class="c">Lagos</span><span class="dot" style="background:var(--aqi-unhealthy)"></span><span class="v">68.2</span><span class="b">Unhealthy</span></span>
+        <span class="tick"><span class="c">Accra</span><span class="dot" style="background:var(--aqi-sensitive)"></span><span class="v">47.3</span><span class="b">Sensitive</span></span>
+        <span class="tick"><span class="c">Dar es Salaam</span><span class="dot" style="background:var(--aqi-moderate)"></span><span class="v">28.9</span><span class="b">Moderate</span></span>
+        <span class="tick"><span class="c">Lusaka</span><span class="dot" style="background:var(--aqi-good)"></span><span class="v">11.2</span><span class="b">Good</span></span>
+        <span class="tick"><span class="c">Abuja</span><span class="dot" style="background:var(--aqi-sensitive)"></span><span class="v">44.1</span><span class="b">Sensitive</span></span>
+        <span class="tick"><span class="c">Kano</span><span class="dot" style="background:var(--aqi-unhealthy)"></span><span class="v">138.7</span><span class="b">Unhealthy</span></span>
+        <span class="tick"><span class="c">Maiduguri</span><span class="dot" style="background:var(--aqi-veryunhealthy)"></span><span class="v">161.0</span><span class="b">Very unhealthy</span></span>
+        <span class="tick"><span class="c">Kumasi</span><span class="dot" style="background:var(--aqi-sensitive)"></span><span class="v">35.9</span><span class="b">Sensitive</span></span>
+        <span class="tick"><span class="c">Nakuru</span><span class="dot" style="background:var(--aqi-moderate)"></span><span class="v">21.7</span><span class="b">Moderate</span></span>
+        <span class="tick"><span class="c">Port Harcourt</span><span class="dot" style="background:var(--aqi-unhealthy)"></span><span class="v">74.5</span><span class="b">Unhealthy</span></span>
+        <span class="tick"><span class="c">Kisumu</span><span class="dot" style="background:var(--aqi-moderate)"></span><span class="v">17.3</span><span class="b">Moderate</span></span>
+        <span class="tick"><span class="c">Ilorin</span><span class="dot" style="background:var(--aqi-sensitive)"></span><span class="v">52.6</span><span class="b">Sensitive</span></span>
+        <span class="tick"><span class="c">Awka</span><span class="dot" style="background:var(--aqi-sensitive)"></span><span class="v">41.9</span><span class="b">Sensitive</span></span>
+        <span class="tick"><span class="c">Akure</span><span class="dot" style="background:var(--aqi-moderate)"></span><span class="v">33.5</span><span class="b">Moderate</span></span>
+        <span class="tick"><span class="c">Ado-Ekiti</span><span class="dot" style="background:var(--aqi-moderate)"></span><span class="v">29.8</span><span class="b">Moderate</span></span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     FOUR MONITORING STREAMS
+     ============================================================ -->
+<section class="section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">What we monitor</p>
+        <h2 class="display">Four streams of evidence</h2>
+      </div>
+      <p class="lede">Low-cost, open-source sensors — deployed and hosted by citizens — turning invisible pollution into public record.</p>
+    </div>
+    <div class="streams-grid">
+      <a class="stream-card" href="air.html">
+        <span class="accent" style="background:var(--aqi-sensitive)" aria-hidden="true"></span>
+        <div class="glyph" aria-hidden="true">🌬️</div>
+        <h3>Air</h3>
+        <p>PM<sub>2.5</sub> and PM<sub>10</sub> particulate readings from Luftdaten-based SDS011 sensors, updated around the clock.</p>
+        <span class="stream-status live">Live network</span>
+        <span class="go" aria-hidden="true">→</span>
+      </a>
+      <a class="stream-card" href="water.html">
+        <span class="accent" style="background:#4fa8d8" aria-hidden="true"></span>
+        <div class="glyph" aria-hidden="true">💧</div>
+        <h3>Water</h3>
+        <p>Quality and safety indicators for the water that African cities drink, wash with and fish from.</p>
+        <span class="stream-status soon">Coming soon</span>
+        <span class="go" aria-hidden="true">→</span>
+      </a>
+      <a class="stream-card" href="sound.html">
+        <span class="accent" style="background:var(--aqi-veryunhealthy)" aria-hidden="true"></span>
+        <div class="glyph" aria-hidden="true">🔊</div>
+        <h3>Sound</h3>
+        <p>Noise-pollution levels near flight paths, highways, markets and construction — mapped block by block.</p>
+        <span class="stream-status soon">Coming soon</span>
+        <span class="go" aria-hidden="true">→</span>
+      </a>
+      <a class="stream-card" href="radiation.html">
+        <span class="accent" style="background:var(--aqi-moderate)" aria-hidden="true"></span>
+        <div class="glyph" aria-hidden="true">☢️</div>
+        <h3>Radiation</h3>
+        <p>Background radiation monitoring for early warning and independent verification.</p>
+        <span class="stream-status soon">Coming soon</span>
+        <span class="go" aria-hidden="true">→</span>
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     MAP
+     ============================================================ -->
+<section class="section map-section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">The network</p>
+        <h2 class="display">Sixteen cities, five countries — and counting</h2>
+      </div>
+      <p class="lede">Each marker is a monitored city, coloured by its current PM<sub>2.5</sub> health band. Tap a marker for the reading.</p>
+    </div>
+    <div class="map-shell">
+      <p class="map-fallback-note" id="map-fallback">Interactive map — requires a network connection for basemap tiles.</p>
+      <div id="africa-map" aria-label="Map of monitored African cities coloured by air-quality band"></div>
+      <div class="map-count">
+        <div class="n">16<span style="color:var(--muted)">/</span>5</div>
+        <div class="l">cities / countries</div>
+      </div>
+      <div class="map-legend" aria-hidden="false">
+        <div class="lg-title">PM2.5 health band (µg/m³)</div>
+        <ul>
+          <li><span class="sw" style="background:var(--aqi-good)"></span>Good ≤ 12</li>
+          <li><span class="sw" style="background:var(--aqi-moderate)"></span>Moderate ≤ 35.4</li>
+          <li><span class="sw" style="background:var(--aqi-sensitive)"></span>Sensitive ≤ 55.4</li>
+          <li><span class="sw" style="background:var(--aqi-unhealthy)"></span>Unhealthy ≤ 150.4</li>
+          <li><span class="sw" style="background:var(--aqi-veryunhealthy)"></span>Very unhealthy ≤ 250.4</li>
+          <li><span class="sw" style="background:var(--aqi-hazardous)"></span>Hazardous &gt; 250.4</li>
+        </ul>
+      </div>
+    </div>
+    <p class="data-note">Sample readings for illustration. Live data credited to the WHO Global Platform on Air Quality &amp; Health.</p>
+  </div>
+</section>
+
+<!-- ============================================================
+     24-HOUR TREND CHART — fully authored in markup, JS optional
+     ============================================================ -->
+<section class="section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">A day in the air</p>
+        <h2 class="display">Nairobi, hour by hour</h2>
+      </div>
+      <p class="lede">Rush hours leave fingerprints. PM<sub>2.5</sub> climbs with the morning commute, eases at midday, and peaks again as the city drives home.</p>
+    </div>
+
+    <div class="chart-card" id="trend-card">
+      <div class="chart-title-row">
+        <h3>PM<sub>2.5</sub> over 24 hours — Nairobi (sample day)</h3>
+        <span class="sub">µg/m³ &middot; illustrative data</span>
+      </div>
+
+      <svg id="trend-chart" class="trend-svg" viewBox="0 0 760 360" role="img"
+           aria-label="Line chart of PM2.5 over 24 hours in Nairobi. Values rise from 18 micrograms per cubic metre at midnight to a morning peak of 41 at 8am, dip to 25 in mid-afternoon, and peak at 52 micrograms per cubic metre at 6pm, well above the WHO guideline of 10.">
+
+        <!-- AQI band background tints (the health scale, in place) -->
+        <rect x="52" y="244.8" width="612" height="55.2" fill="var(--aqi-good)" opacity="0.06"></rect>
+        <rect x="52" y="137.2" width="612" height="107.6" fill="var(--aqi-moderate)" opacity="0.06"></rect>
+        <rect x="52" y="45.2"  width="612" height="92"    fill="var(--aqi-sensitive)" opacity="0.06"></rect>
+        <rect x="52" y="24"    width="612" height="21.2"  fill="var(--aqi-unhealthy)" opacity="0.06"></rect>
+
+        <!-- band labels (right rail) -->
+        <g font-size="10" fill="var(--muted)" text-anchor="start">
+          <circle cx="674" cy="272" r="3.5" fill="var(--aqi-good)"></circle><text x="683" y="275.5">Good</text>
+          <circle cx="674" cy="191" r="3.5" fill="var(--aqi-moderate)"></circle><text x="683" y="194.5">Moderate</text>
+          <circle cx="674" cy="91"  r="3.5" fill="var(--aqi-sensitive)"></circle><text x="683" y="94.5">Sensitive</text>
+          <circle cx="674" cy="34"  r="3.5" fill="var(--aqi-unhealthy)"></circle><text x="683" y="37.5">Unhealthy</text>
+        </g>
+
+        <!-- gridlines: solid hairlines, one step off the surface -->
+        <g stroke="rgba(255,255,255,0.08)" stroke-width="1" shape-rendering="crispEdges">
+          <line x1="52" y1="24"  x2="664" y2="24"></line>
+          <line x1="52" y1="116" x2="664" y2="116"></line>
+          <line x1="52" y1="208" x2="664" y2="208"></line>
+        </g>
+        <!-- baseline (x-axis) -->
+        <line x1="52" y1="300" x2="664" y2="300" stroke="rgba(255,255,255,0.16)" stroke-width="1" shape-rendering="crispEdges"></line>
+
+        <!-- y-axis tick labels -->
+        <g font-size="11" fill="var(--muted)" text-anchor="end" style="font-variant-numeric:tabular-nums">
+          <text x="44" y="304">0</text>
+          <text x="44" y="212">20</text>
+          <text x="44" y="120">40</text>
+          <text x="44" y="28">60</text>
+        </g>
+
+        <!-- x-axis tick labels -->
+        <g font-size="11" fill="var(--muted)" text-anchor="middle" style="font-variant-numeric:tabular-nums">
+          <text x="52"    y="322" text-anchor="start">00:00</text>
+          <text x="211.7" y="322">06:00</text>
+          <text x="371.3" y="322">12:00</text>
+          <text x="531"   y="322">18:00</text>
+          <text x="664"   y="322" text-anchor="end">23:00</text>
+        </g>
+        <text x="52" y="345" font-size="10" fill="var(--muted)">Hour of day (EAT) · sample values, hourly means</text>
+
+        <!-- WHO guideline reference line (threshold → dashed, labeled) -->
+        <line x1="52" y1="254" x2="664" y2="254" stroke="var(--aqi-good)" stroke-width="1.5" stroke-dasharray="6 5"></line>
+        <text x="58" y="248" font-size="10.5" fill="var(--text-2)" font-weight="500">WHO guideline (10 µg/m³)</text>
+
+        <!-- area wash under the line (~8% opacity) -->
+        <path fill="var(--aqi-sensitive)" opacity="0.08" d="M52,300 L52,217.2 L78.6,226.4 L105.2,231 L131.8,235.6 L158.4,240.2 L185,231 L211.7,198.8 L238.3,143.6 L264.9,111.4 L291.5,125.2 L318.1,152.8 L344.7,171.2 L371.3,180.4 L397.9,185 L424.5,175.8 L451.1,162 L477.7,134.4 L504.3,97.6 L531,60.8 L557.6,79.2 L584.2,116 L610.8,148.2 L637.4,180.4 L664,203.4 L664,300 Z"></path>
+
+        <!-- data line: 2px, round joins, fully visible with zero JS -->
+        <polyline id="trend-line" fill="none" stroke="var(--aqi-sensitive)" stroke-width="2"
+                  stroke-linejoin="round" stroke-linecap="round"
+                  points="52,217.2 78.6,226.4 105.2,231 131.8,235.6 158.4,240.2 185,231 211.7,198.8 238.3,143.6 264.9,111.4 291.5,125.2 318.1,152.8 344.7,171.2 371.3,180.4 397.9,185 424.5,175.8 451.1,162 477.7,134.4 504.3,97.6 531,60.8 557.6,79.2 584.2,116 610.8,148.2 637.4,180.4 664,203.4"></polyline>
+
+        <!-- selective direct labels: the peak and the endpoint -->
+        <circle cx="531" cy="60.8" r="4.5" fill="var(--aqi-sensitive)" stroke="var(--ink-2)" stroke-width="2"></circle>
+        <text x="531" y="46" font-size="12" font-weight="700" fill="var(--text)" text-anchor="middle">52</text>
+        <text x="531" y="33" font-size="9.5" fill="var(--text-2)" text-anchor="middle">evening peak</text>
+        <circle cx="664" cy="203.4" r="4.5" fill="var(--aqi-sensitive)" stroke="var(--ink-2)" stroke-width="2"></circle>
+        <text x="656" y="196" font-size="12" font-weight="700" fill="var(--text)" text-anchor="end">21</text>
+
+        <!-- hover layer (populated by JS as progressive enhancement) -->
+        <g id="trend-hover" aria-hidden="true"></g>
+      </svg>
+
+      <div class="chart-tip" id="trend-tip" role="status" aria-live="off"></div>
+
+      <details class="chart-table">
+        <summary>View this chart as a table</summary>
+        <table>
+          <caption class="sub" style="text-align:left;padding:4px 0;color:var(--muted)">Hourly PM2.5 (µg/m³), Nairobi — sample day</caption>
+          <tr><th scope="row">Hour</th><td>00</td><td>01</td><td>02</td><td>03</td><td>04</td><td>05</td><td>06</td><td>07</td><td>08</td><td>09</td><td>10</td><td>11</td></tr>
+          <tr><th scope="row">PM2.5</th><td>18</td><td>16</td><td>15</td><td>14</td><td>13</td><td>15</td><td>22</td><td>34</td><td>41</td><td>38</td><td>32</td><td>28</td></tr>
+          <tr><th scope="row">Hour</th><td>12</td><td>13</td><td>14</td><td>15</td><td>16</td><td>17</td><td>18</td><td>19</td><td>20</td><td>21</td><td>22</td><td>23</td></tr>
+          <tr><th scope="row">PM2.5</th><td>26</td><td>25</td><td>27</td><td>30</td><td>36</td><td>44</td><td>52</td><td>48</td><td>40</td><td>33</td><td>26</td><td>21</td></tr>
+        </table>
+      </details>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     WHY IT MATTERS — paper reading surface with impact stats
+     ============================================================ -->
+<section class="section paper-section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <p class="kicker">Why it matters</p>
+    <h2 class="display">Pollution is a public-health story hiding in plain sight</h2>
+    <div class="impact-grid">
+      <div class="impact-prose">
+        <p>
+          Air pollution is linked to roughly <strong>one in nine deaths worldwide</strong>. The World Health
+          Organization attributes about <strong>seven million premature deaths every year</strong> to it —
+          around 4.2&nbsp;million from ambient (outdoor) pollution and 3.8&nbsp;million from household air.
+        </p>
+        <p>
+          Yet across much of Africa the data needed to act on this — street-level, hour-by-hour,
+          independently verifiable — barely exists. sensors.AFRICA closes that gap by putting
+          low-cost, open-source sensors in the hands of citizens, then publishing what they find
+          as open data anyone can interrogate: a journalist chasing a lead, a parent choosing a
+          school route, a city official defending a budget.
+        </p>
+      </div>
+      <div class="stat-tiles" aria-label="Share of deaths linked to air pollution, by cause (WHO)">
+        <div class="stat-tile">
+          <div class="val">~36%</div>
+          <div class="lbl">of lung-cancer deaths are linked to air pollution</div>
+          <div class="bar" aria-hidden="true"><i style="width:36%;background:var(--aqi-hazardous)"></i></div>
+        </div>
+        <div class="stat-tile">
+          <div class="val">~35%</div>
+          <div class="lbl">of deaths from COPD are linked to air pollution</div>
+          <div class="bar" aria-hidden="true"><i style="width:35%;background:var(--aqi-veryunhealthy)"></i></div>
+        </div>
+        <div class="stat-tile">
+          <div class="val">~34%</div>
+          <div class="lbl">of stroke deaths are linked to air pollution</div>
+          <div class="bar" aria-hidden="true"><i style="width:34%;background:var(--aqi-unhealthy)"></i></div>
+        </div>
+        <div class="stat-tile">
+          <div class="val">~27%</div>
+          <div class="lbl">of heart-disease deaths are linked to air pollution</div>
+          <div class="bar" aria-hidden="true"><i style="width:27%;background:var(--aqi-sensitive)"></i></div>
+        </div>
+      </div>
+    </div>
+    <p class="paper-credit">Figures: World Health Organization. Air-quality data credited to the WHO Global Platform on Air Quality &amp; Health.</p>
+  </div>
+</section>
+
+<!-- ============================================================
+     STORIES
+     ============================================================ -->
+<section class="section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">From the network</p>
+        <h2 class="display">Data becomes journalism</h2>
+      </div>
+      <p class="lede">Sensor readings are only the start. Our reporting turns them into stories cities can act on.</p>
+    </div>
+    <div class="stories-grid">
+      <a class="story-card" href="stories.html">
+        <div class="story-visual" aria-hidden="true">
+          <svg viewBox="0 0 400 150" preserveAspectRatio="none">
+            <rect width="400" height="150" fill="#10141d"></rect>
+            <path d="M0,120 Q60,70 120,95 T240,60 T400,80 L400,150 L0,150 Z" fill="var(--aqi-veryunhealthy)" opacity="0.25"></path>
+            <path d="M0,130 Q80,95 160,110 T320,85 T400,100 L400,150 L0,150 Z" fill="#4fa8d8" opacity="0.3"></path>
+            <circle cx="310" cy="42" r="16" fill="none" stroke="var(--aqi-moderate)" stroke-width="2" opacity="0.7"></circle>
+            <circle cx="310" cy="42" r="28" fill="none" stroke="var(--aqi-moderate)" stroke-width="1" opacity="0.35"></circle>
+          </svg>
+        </div>
+        <div class="story-body">
+          <span class="story-tag">Featured initiative</span>
+          <h3>StormWatch: early warnings on Lake Victoria</h3>
+          <p>A storm early-warning system for Lake Victoria — using sensor data to protect the fishing communities who work one of the world's most dangerous lakes.</p>
+          <span class="story-more">Read the story →</span>
+        </div>
+      </a>
+      <a class="story-card" href="stories.html">
+        <div class="story-visual" aria-hidden="true">
+          <svg viewBox="0 0 400 150" preserveAspectRatio="none">
+            <rect width="400" height="150" fill="#10141d"></rect>
+            <g opacity="0.85">
+              <rect x="30"  y="90" width="22" height="60" fill="var(--aqi-good)" opacity="0.5"></rect>
+              <rect x="70"  y="70" width="22" height="80" fill="var(--aqi-moderate)" opacity="0.5"></rect>
+              <rect x="110" y="45" width="22" height="105" fill="var(--aqi-sensitive)" opacity="0.55"></rect>
+              <rect x="150" y="25" width="22" height="125" fill="var(--aqi-unhealthy)" opacity="0.55"></rect>
+              <rect x="190" y="55" width="22" height="95" fill="var(--aqi-sensitive)" opacity="0.55"></rect>
+              <rect x="230" y="80" width="22" height="70" fill="var(--aqi-moderate)" opacity="0.5"></rect>
+              <rect x="270" y="95" width="22" height="55" fill="var(--aqi-good)" opacity="0.5"></rect>
+            </g>
+          </svg>
+        </div>
+        <div class="story-body">
+          <span class="story-tag">Air &middot; Nairobi</span>
+          <h3>What a sensor on your street corner can prove</h3>
+          <p>Hyper-local readings expose what citywide averages hide: the school gate at rush hour, the road by the dumpsite, the block downwind of the factory.</p>
+          <span class="story-more">Read the story →</span>
+        </div>
+      </a>
+      <a class="story-card" href="https://medium.com/@sensors.AFRICA" rel="noopener">
+        <div class="story-visual" aria-hidden="true">
+          <svg viewBox="0 0 400 150" preserveAspectRatio="none">
+            <rect width="400" height="150" fill="#10141d"></rect>
+            <g fill="none" stroke-width="2" stroke-linecap="round">
+              <path d="M20,110 C80,105 120,60 180,70 S300,40 380,55" stroke="var(--aqi-sensitive)" opacity="0.8"></path>
+              <path d="M20,125 C90,120 140,95 200,100 S310,80 380,90" stroke="var(--aqi-good)" opacity="0.6"></path>
+            </g>
+            <line x1="20" y1="132" x2="380" y2="132" stroke="rgba(255,255,255,0.15)"></line>
+          </svg>
+        </div>
+        <div class="story-body">
+          <span class="story-tag">Dispatches &middot; Medium</span>
+          <h3>Field notes from a citizen-science network</h3>
+          <p>Deployment diaries, methodology notes and investigations from the sensors.AFRICA team and its partners — published openly on Medium.</p>
+          <span class="story-more">Read on Medium →</span>
+        </div>
+      </a>
+    </div>
+    <p class="stories-foot">All stories → <a href="stories.html">stories</a> · or follow <a href="https://medium.com/@sensors.AFRICA" rel="noopener">sensors.AFRICA on Medium</a></p>
+  </div>
+</section>
+
+<!-- ============================================================
+     HOW IT WORKS
+     ============================================================ -->
+<section class="section" style="padding-top:0">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">How it works</p>
+        <h2 class="display">A weather station for pollution, on your wall</h2>
+      </div>
+    </div>
+    <div class="how-grid">
+      <div class="how-step">
+        <div class="num">1</div>
+        <h3>Get a sensor</h3>
+        <p>We use open-source Luftdaten technology built around the SDS011 particulate sensor — cheap enough for a household, accurate enough for a newsroom.</p>
+      </div>
+      <div class="how-step">
+        <div class="num">2</div>
+        <h3>Mount it &amp; connect</h3>
+        <p>Fix it outside a window or on a balcony, connect it to Wi-Fi, and it starts measuring PM<sub>2.5</sub> and PM<sub>10</sub> in the air around your home.</p>
+      </div>
+      <div class="how-step">
+        <div class="num">3</div>
+        <h3>Your data goes public</h3>
+        <p>Readings stream to the open sensors.AFRICA platform — mapped, archived and free for journalists, researchers and neighbours to use.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     CTA
+     ============================================================ -->
+<section class="cta-section">
+  <div class="cta-inner">
+    <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <h2>Your city can't fix what it can't see.</h2>
+    <p>Host a sensor at your home, school or office and put your street on the map. No lab coat required — just a window ledge and Wi-Fi.</p>
+    <a class="btn btn-primary" href="get-started.html">Get started — join the network</a>
+  </div>
+</section>
+
+</main>
+
+<!-- ============================================================
+     FOOTER
+     ============================================================ -->
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+        <p class="footer-mission">A pan-African citizen science initiative using sensors to monitor air, water and sound pollution — giving citizens actionable information about their cities.</p>
+      </div>
+      <div class="footer-col">
+        <h4>Network</h4>
+        <ul>
+          <li><a href="air.html">Air quality</a></li>
+          <li><a href="water.html">Water</a></li>
+          <li><a href="sound.html">Sound</a></li>
+          <li><a href="radiation.html">Radiation</a></li>
+          <li><a href="data.html">Open data</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Community</h4>
+        <ul>
+          <li><a href="stories.html">Stories</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="get-started.html">Get a sensor</a></li>
+          <li><a href="https://twitter.com/sensorsAFRICA/" rel="noopener">Twitter</a></li>
+          <li><a href="https://www.instagram.com/sensorsAFRICA/" rel="noopener">Instagram</a></li>
+          <li><a href="https://medium.com/@sensors.AFRICA" rel="noopener">Medium</a></li>
+          <li><a href="https://github.com/CodeForAfrica/sensors.AFRICA" rel="noopener">GitHub</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Partners</h4>
+        <ul>
+          <li><a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a></li>
+          <li><a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a></li>
+          <li><a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>Incubated by <a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a> · seed-funded by <a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a> · powered by <a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></span>
+      <span>Redesign prototype — all readings on this page are illustrative sample data.</span>
+    </div>
+  </div>
+</footer>
+
+<!-- ============================================================
+     SCRIPT 1 — MAP (isolated; failure here cannot affect chart/ticker)
+     ============================================================ -->
+<script>
+try {
+  // EPA PM2.5 breakpoints → AQI band color + name
+  function aqiBand(v){
+    if (v <= 12)    return { color:'#46d17f', name:'Good' };
+    if (v <= 35.4)  return { color:'#f4c542', name:'Moderate' };
+    if (v <= 55.4)  return { color:'#f5822e', name:'Unhealthy for sensitive groups' };
+    if (v <= 150.4) return { color:'#ef5350', name:'Unhealthy' };
+    if (v <= 250.4) return { color:'#b06ae0', name:'Very unhealthy' };
+    return { color:'#c0466c', name:'Hazardous' };
+  }
+
+  var CITIES = [
+    { name:'Nairobi',        country:'Kenya',    lat:-1.2864,  lng:36.8172,  pm25:38.4 },
+    { name:'Nakuru',         country:'Kenya',    lat:-0.3031,  lng:36.0800,  pm25:21.7 },
+    { name:'Kisumu',         country:'Kenya',    lat:-0.0917,  lng:34.7680,  pm25:17.3 },
+    { name:'Dar es Salaam',  country:'Tanzania', lat:-6.7924,  lng:39.2083,  pm25:28.9 },
+    { name:'Lagos',          country:'Nigeria',  lat:6.5244,   lng:3.3792,   pm25:68.2 },
+    { name:'Abuja',          country:'Nigeria',  lat:9.0765,   lng:7.3986,   pm25:44.1 },
+    { name:'Ilorin',         country:'Nigeria',  lat:8.4966,   lng:4.5421,   pm25:52.6 },
+    { name:'Maiduguri',      country:'Nigeria',  lat:11.8333,  lng:13.1510,  pm25:161.0 },
+    { name:'Port Harcourt',  country:'Nigeria',  lat:4.8156,   lng:7.0498,   pm25:74.5 },
+    { name:'Kano',           country:'Nigeria',  lat:12.0022,  lng:8.5920,   pm25:138.7 },
+    { name:'Awka',           country:'Nigeria',  lat:6.2120,   lng:7.0740,   pm25:41.9 },
+    { name:'Akure',          country:'Nigeria',  lat:7.2571,   lng:5.2058,   pm25:33.5 },
+    { name:'Ado-Ekiti',      country:'Nigeria',  lat:7.6233,   lng:5.2210,   pm25:29.8 },
+    { name:'Accra',          country:'Ghana',    lat:5.6037,   lng:-0.1870,  pm25:47.3 },
+    { name:'Kumasi',         country:'Ghana',    lat:6.6885,   lng:-1.6244,  pm25:35.9 },
+    { name:'Lusaka',         country:'Zambia',   lat:-15.3875, lng:28.3228,  pm25:11.2 }
+  ];
+
+  if (typeof L !== 'undefined') {
+    var map = L.map('africa-map', {
+      center: [2.5, 18],
+      zoom: 4,
+      minZoom: 3,
+      maxZoom: 10,
+      scrollWheelZoom: false,
+      attributionControl: true
+    });
+
+    // CARTO dark basemap — the shell behind it carries a styled fallback
+    // background, so a tile failure never looks broken.
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>',
+      subdomains: 'abcd',
+      maxZoom: 19
+    }).addTo(map);
+
+    CITIES.forEach(function (c) {
+      var band = aqiBand(c.pm25);
+      L.circleMarker([c.lat, c.lng], {
+        radius: 8,
+        color: '#0c0f16',       // 2px surface ring so overlapping markers stay legible
+        weight: 2,
+        fillColor: band.color,
+        fillOpacity: 0.95
+      }).addTo(map).bindPopup(
+        '<div class="popup-city">' + c.name + ', ' + c.country + '</div>' +
+        '<div class="popup-reading">PM2.5 <strong>' + c.pm25.toFixed(1) + ' µg/m³</strong></div>' +
+        '<div style="color:' + band.color + ';font-size:.75rem;margin-top:2px">&#9679; <span style="color:#9aa2b1">' + band.name + '</span></div>' +
+        '<div style="color:#6b7280;font-size:.68rem;margin-top:4px">Sample reading — illustrative</div>'
+      );
+    });
+
+    // Map is live: retire the static fallback note
+    var note = document.getElementById('map-fallback');
+    if (note) note.style.display = 'none';
+  }
+} catch (err) {
+  // Map failure is cosmetic: the shell keeps its styled fallback background.
+  console.warn('Map init skipped:', err && err.message);
+}
+</script>
+
+<!-- ============================================================
+     SCRIPT 2 — CHART hover layer (progressive enhancement only;
+     the chart is fully rendered in static markup above)
+     ============================================================ -->
+<script>
+try {
+  var HOURS = [18,16,15,14,13,15,22,34,41,38,32,28,26,25,27,30,36,44,52,48,40,33,26,21];
+  var svg  = document.getElementById('trend-chart');
+  var card = document.getElementById('trend-card');
+  var tip  = document.getElementById('trend-tip');
+  var hoverG = document.getElementById('trend-hover');
+
+  if (svg && card && tip && hoverG) {
+    var SVGNS = 'http://www.w3.org/2000/svg';
+    var X0 = 52, XW = 612, Y0 = 300, YS = 276 / 60;
+
+    // wide hover hit area (whole plot), nearest-point crosshair + dot
+    var cross = document.createElementNS(SVGNS, 'line');
+    cross.setAttribute('stroke', 'rgba(255,255,255,0.25)');
+    cross.setAttribute('stroke-width', '1');
+    cross.setAttribute('y1', '24'); cross.setAttribute('y2', '300');
+    cross.style.display = 'none';
+    hoverG.appendChild(cross);
+
+    var dot = document.createElementNS(SVGNS, 'circle');
+    dot.setAttribute('r', '5');
+    dot.setAttribute('fill', '#f5822e');
+    dot.setAttribute('stroke', '#141821');
+    dot.setAttribute('stroke-width', '2');
+    dot.style.display = 'none';
+    hoverG.appendChild(dot);
+
+    function hideHover(){ cross.style.display = 'none'; dot.style.display = 'none'; tip.style.display = 'none'; }
+
+    svg.addEventListener('mousemove', function (e) {
+      var rect = svg.getBoundingClientRect();
+      var sx = 760 / rect.width;                     // CSS px → viewBox units
+      var vx = (e.clientX - rect.left) * sx;
+      if (vx < X0 - 10 || vx > X0 + XW + 10) { hideHover(); return; }
+      var i = Math.round((vx - X0) / (XW / 23));
+      i = Math.max(0, Math.min(23, i));
+      var px = X0 + i * (XW / 23);
+      var py = Y0 - HOURS[i] * YS;
+
+      cross.setAttribute('x1', px); cross.setAttribute('x2', px);
+      cross.style.display = '';
+      dot.setAttribute('cx', px); dot.setAttribute('cy', py);
+      dot.style.display = '';
+
+      tip.textContent = String(i).padStart(2, '0') + ':00 — ' + HOURS[i] + ' µg/m³';
+      tip.style.display = 'block';
+      var cardRect = card.getBoundingClientRect();
+      tip.style.left = ((px / 760) * rect.width + rect.left - cardRect.left) + 'px';
+      tip.style.top  = ((py / 360) * rect.height + rect.top - cardRect.top) + 'px';
+    });
+    svg.addEventListener('mouseleave', hideHover);
+  }
+} catch (err) {
+  console.warn('Chart hover enhancement skipped:', err && err.message);
+}
+</script>
+
+<!-- ============================================================
+     SCRIPT 3 — TICKER / clock niceties (isolated; ticker content
+     and its marquee are pure HTML + CSS and work with zero JS)
+     ============================================================ -->
+<script>
+try {
+  // Timestamp the hero panel with a plausible "last updated" time
+  var updated = document.getElementById('hero-updated');
+  if (updated) {
+    var now = new Date();
+    updated.textContent = String(now.getHours()).padStart(2, '0') + ':' +
+                          String(now.getMinutes()).padStart(2, '0') + ' local';
+  }
+
+  // Scale the marquee duration to its content so speed stays consistent
+  var track = document.getElementById('ticker-track');
+  var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (track && !reduce) {
+    var w = track.scrollWidth / 2;                  // one set's width
+    track.style.animationDuration = Math.max(30, Math.round(w / 55)) + 's';
+  }
+} catch (err) {
+  console.warn('Ticker enhancement skipped:', err && err.message);
+}
+</script>
+
+</body>
+</html>

--- a/redesign/radiation.html
+++ b/redesign/radiation.html
@@ -1,0 +1,436 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Radiation — coming soon · sensors.AFRICA</title>
+<meta name="description" content="sensors.AFRICA is preparing a radiation stream: citizen-hosted detectors establishing an open, independent baseline of ambient radiation levels. Coming soon — air is our live network today.">
+
+<!-- Fonts: Fraunces (display serif) · Space Grotesk (data) · Inter (body) -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Space+Grotesk:wght@400;500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+
+<style>
+/* ============================================================
+   TOKENS — shared with all subpages, do not diverge
+   ============================================================ */
+:root{
+  --ink:#0c0f16; --ink-2:#141821; --ink-3:#1a1f2b;
+  --paper:#f1eee7; --paper-ink:#17140f;
+  --text:#e9ebf0; --text-2:#9aa2b1; --muted:#6b7280;
+  --hair:rgba(255,255,255,0.09); --hair-strong:rgba(255,255,255,0.16);
+  --aqi-good:#46d17f; --aqi-moderate:#f4c542; --aqi-sensitive:#f5822e;
+  --aqi-unhealthy:#ef5350; --aqi-veryunhealthy:#b06ae0; --aqi-hazardous:#c0466c;
+  --serif:"Fraunces",Georgia,serif;
+  --sans:"Inter",system-ui,-apple-system,sans-serif;
+  --data:"Space Grotesk","Inter",system-ui,sans-serif;
+  --maxw:1200px;
+  /* page accent — RADIATION (violet, from the AQI spine) */
+  --accent:#b06ae0; --accent-soft:rgba(176,106,224,.10); --accent-hover:#c286ea;
+}
+
+/* ============================================================
+   BASE
+   ============================================================ */
+*{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  background:var(--ink); color:var(--text);
+  font-family:var(--sans); font-size:16px; line-height:1.6;
+  -webkit-font-smoothing:antialiased;
+}
+img{max-width:100%;display:block}
+a{color:inherit}
+:focus-visible{outline:2px solid var(--aqi-moderate);outline-offset:3px;border-radius:2px}
+::selection{background:var(--accent);color:var(--ink)}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
+.kicker{
+  font-family:var(--data);font-size:.75rem;font-weight:500;
+  letter-spacing:.18em;text-transform:uppercase;color:var(--text-2);
+}
+h2.display{
+  font-family:var(--serif);font-weight:600;font-size:clamp(1.7rem,3.4vw,2.6rem);
+  line-height:1.12;letter-spacing:-.01em;margin:10px 0 14px;
+}
+
+/* The AQI spine — a segmented band used as the site's structural accent */
+.aqi-spine{display:flex;height:4px;width:100%}
+.aqi-spine span{flex:1}
+.aqi-spine .s1{background:var(--aqi-good)}
+.aqi-spine .s2{background:var(--aqi-moderate)}
+.aqi-spine .s3{background:var(--aqi-sensitive)}
+.aqi-spine .s4{background:var(--aqi-unhealthy)}
+.aqi-spine .s5{background:var(--aqi-veryunhealthy)}
+.aqi-spine .s6{background:var(--aqi-hazardous)}
+.spine-sm{width:64px;height:4px;margin-bottom:14px}
+
+/* ============================================================
+   HEADER — identical shell across the site
+   ============================================================ */
+.site-header{
+  position:sticky;top:0;z-index:1000;
+  background:rgba(12,15,22,.88);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+  border-bottom:1px solid var(--hair);
+}
+.header-inner{
+  max-width:var(--maxw);margin:0 auto;padding:0 24px;
+  display:flex;align-items:center;justify-content:space-between;gap:20px;height:64px;
+}
+.wordmark{
+  font-family:var(--data);font-weight:700;font-size:1.05rem;letter-spacing:.01em;
+  text-decoration:none;white-space:nowrap;
+}
+.wordmark .dot-africa{color:var(--aqi-good)}
+.main-nav{display:flex;gap:2px;align-items:center;overflow-x:auto}
+.main-nav a{
+  font-family:var(--data);font-size:.82rem;font-weight:500;color:var(--text-2);
+  text-decoration:none;padding:8px 11px;border-radius:6px;white-space:nowrap;
+}
+.main-nav a:hover{color:var(--text);background:var(--ink-3)}
+.main-nav a[aria-current="page"]{color:var(--text);background:var(--ink-3)}
+.main-nav a.live-link{color:var(--text)}
+.main-nav a.live-link::before{
+  content:"";display:inline-block;width:6px;height:6px;border-radius:50%;
+  background:var(--aqi-good);margin-right:7px;vertical-align:1px;
+}
+.nav-cta{
+  font-family:var(--data);font-size:.82rem;font-weight:700;text-decoration:none;
+  color:var(--ink);background:var(--aqi-good);padding:9px 16px;border-radius:999px;white-space:nowrap;
+}
+.nav-cta:hover{background:#5fdd92}
+
+/* ============================================================
+   HERO — coming-soon data-stream layout (shared template)
+   ============================================================ */
+.hero{position:relative;overflow:hidden;border-bottom:1px solid var(--hair)}
+.hero::before{ /* faint accent wash */
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:
+    radial-gradient(52rem 30rem at 78% -10%, var(--accent-soft), transparent 60%),
+    radial-gradient(44rem 26rem at 8% 110%, rgba(70,209,127,.05), transparent 60%);
+}
+.hero-grid{
+  position:relative;display:grid;grid-template-columns:minmax(0,1.15fr) minmax(0,.85fr);
+  gap:56px;align-items:center;padding:76px 0 68px;
+}
+.hero h1{
+  font-family:var(--serif);font-weight:640;font-variation-settings:"opsz" 100;
+  font-size:clamp(2.5rem,5.4vw,4.3rem);line-height:1.04;letter-spacing:-.015em;
+}
+.hero h1 em{font-style:italic;font-weight:520;color:var(--accent)}
+.hero .standfirst{margin-top:22px;font-size:1.08rem;color:var(--text-2);max-width:52ch}
+.hero-actions{margin-top:30px;display:flex;gap:14px;flex-wrap:wrap;align-items:center}
+.btn{
+  font-family:var(--data);font-weight:700;font-size:.92rem;text-decoration:none;
+  padding:13px 24px;border-radius:999px;display:inline-block;
+}
+.btn-accent{background:var(--accent);color:var(--ink)}
+.btn-accent:hover{background:var(--accent-hover)}
+.btn-ghost{color:var(--text);border:1px solid var(--hair-strong)}
+.btn-ghost:hover{border-color:var(--text-2)}
+.proto-badge{
+  display:inline-flex;align-items:center;gap:7px;margin-top:26px;
+  font-family:var(--data);font-size:.68rem;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--muted);border:1px solid var(--hair);border-radius:999px;padding:5px 12px;
+}
+.proto-badge::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--aqi-moderate)}
+
+/* honest status badge — this stream is not live yet */
+.soon-badge{
+  display:inline-flex;align-items:center;gap:9px;margin-bottom:22px;
+  font-family:var(--data);font-size:.72rem;font-weight:700;letter-spacing:.16em;text-transform:uppercase;
+  color:var(--accent);border:1px solid var(--accent);border-radius:999px;padding:7px 16px;
+}
+.soon-badge::before{content:"";width:7px;height:7px;border-radius:50%;border:2px solid var(--accent)}
+.live-note{margin-top:14px;font-family:var(--data);font-size:.8rem;color:var(--muted)}
+.live-note a{color:var(--text-2)}
+.live-note a:hover{color:var(--text)}
+
+/* Preview panel — planned metrics, deliberately shown without data */
+.preview-panel{
+  position:relative;background:var(--ink-2);border:1px solid var(--hair-strong);
+  border-radius:16px;padding:26px 28px 24px;box-shadow:0 24px 60px rgba(0,0,0,.45);
+}
+.preview-panel .panel-accent{
+  position:absolute;top:0;left:0;right:0;height:4px;
+  border-radius:16px 16px 0 0;background:var(--accent);
+}
+.panel-top{display:flex;justify-content:space-between;align-items:baseline;gap:12px;margin-top:6px}
+.panel-title{font-family:var(--serif);font-size:1.4rem;font-weight:600}
+.panel-status{
+  font-family:var(--data);font-size:.66rem;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--muted);border:1px solid var(--hair);border-radius:999px;padding:4px 11px;white-space:nowrap;
+}
+.metric-list{list-style:none;margin-top:20px}
+.metric-list li{
+  display:flex;justify-content:space-between;align-items:baseline;gap:14px;
+  padding:11px 0;border-bottom:1px solid var(--hair);
+  font-family:var(--data);font-size:.88rem;
+}
+.metric-list li:last-child{border-bottom:0}
+.metric-list .m{color:var(--text-2)}
+.metric-list .v{color:var(--muted);font-variant-numeric:tabular-nums;letter-spacing:.08em}
+.metric-list .u{color:var(--muted);font-size:.72rem;margin-left:6px}
+.panel-foot{
+  margin-top:14px;padding-top:14px;border-top:1px solid var(--hair);
+  font-family:var(--data);font-size:.72rem;color:var(--muted);
+}
+
+/* ============================================================
+   PAPER SECTION — why it matters (warm reading surface)
+   ============================================================ */
+.section{padding:84px 0}
+.paper-section{background:var(--paper);color:var(--paper-ink)}
+.paper-section .kicker{color:#6d675c}
+.paper-section h2.display{color:var(--paper-ink)}
+.impact-grid{display:grid;grid-template-columns:1.1fr .9fr;gap:56px;align-items:start;margin-top:20px}
+.impact-prose{font-family:var(--serif);font-size:1.16rem;line-height:1.72;color:#2c2820;font-weight:420}
+.impact-prose p+p{margin-top:1.1em}
+.impact-prose strong{font-weight:640;color:var(--paper-ink)}
+.stat-tiles{display:grid;grid-template-columns:1fr;gap:14px}
+.stat-tile{background:#fff;border:1px solid #e2ddd1;border-radius:12px;padding:20px 20px 18px}
+.stat-tile .val{font-family:var(--data);font-weight:700;font-size:2.1rem;line-height:1.1;color:var(--paper-ink)}
+.stat-tile .lbl{font-size:.8rem;color:#6d675c;margin-top:6px;line-height:1.45}
+.stat-tile .bar{height:4px;border-radius:2px;background:#ece8dd;margin-top:14px;overflow:hidden}
+.stat-tile .bar i{display:block;height:100%;border-radius:2px}
+.paper-credit{margin-top:34px;font-family:var(--data);font-size:.74rem;color:#8a8375}
+
+/* ============================================================
+   CTA — notify me / stay updated
+   ============================================================ */
+.cta-section{position:relative;overflow:hidden;border-top:1px solid var(--hair)}
+.cta-section::before{
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:radial-gradient(50rem 26rem at 50% 120%, var(--accent-soft), transparent 65%);
+}
+.cta-inner{position:relative;text-align:center;padding:96px 24px;max-width:760px;margin:0 auto}
+.cta-inner h2{
+  font-family:var(--serif);font-weight:640;font-size:clamp(2rem,4.4vw,3.3rem);
+  line-height:1.08;letter-spacing:-.015em;
+}
+.cta-inner p{margin:20px auto 32px;color:var(--text-2);max-width:46ch}
+.cta-inner .aqi-spine{width:120px;margin:0 auto 28px}
+.cta-proto{margin-top:30px;font-family:var(--data);font-size:.74rem;color:var(--muted)}
+
+/* ============================================================
+   FOOTER — identical shell across the site
+   ============================================================ */
+.site-footer{background:#080a10;border-top:1px solid var(--hair);padding:64px 0 40px}
+.footer-grid{display:grid;grid-template-columns:1.4fr 1fr 1fr 1fr;gap:40px}
+.footer-mission{font-size:.9rem;color:var(--text-2);margin-top:14px;max-width:38ch}
+.footer-col h4{
+  font-family:var(--data);font-size:.66rem;font-weight:700;letter-spacing:.16em;
+  text-transform:uppercase;color:var(--muted);margin-bottom:16px;
+}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:9px}
+.footer-col a{font-size:.88rem;color:var(--text-2);text-decoration:none}
+.footer-col a:hover{color:var(--text)}
+.footer-bottom{
+  margin-top:52px;padding-top:22px;border-top:1px solid var(--hair);
+  display:flex;justify-content:space-between;gap:14px;flex-wrap:wrap;
+  font-family:var(--data);font-size:.74rem;color:var(--muted);
+}
+.footer-bottom a{color:var(--text-2)}
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width:1020px){
+  .footer-grid{grid-template-columns:1fr 1fr}
+  .impact-grid{grid-template-columns:1fr;gap:36px}
+}
+@media (max-width:820px){
+  .hero-grid{grid-template-columns:1fr;gap:40px;padding:56px 0}
+  .main-nav{display:none}
+}
+@media (max-width:600px){
+  .footer-grid{grid-template-columns:1fr}
+  .section{padding:60px 0}
+}
+
+/* ============================================================
+   REDUCED MOTION
+   ============================================================ */
+@media (prefers-reduced-motion:reduce){
+  html{scroll-behavior:auto}
+}
+</style>
+</head>
+<body>
+
+<!-- ============================================================
+     HEADER
+     ============================================================ -->
+<header class="site-header">
+  <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+  <div class="header-inner">
+    <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+    <nav class="main-nav" aria-label="Primary">
+      <a class="live-link" href="air.html">Air</a>
+      <a href="water.html">Water</a>
+      <a href="sound.html">Sound</a>
+      <a href="radiation.html" aria-current="page">Radiation</a>
+      <a href="data.html">Data</a>
+      <a href="stories.html">Stories</a>
+      <a href="about.html">About</a>
+    </nav>
+    <a class="nav-cta" href="get-started.html">Get a sensor</a>
+  </div>
+</header>
+
+<main>
+
+<!-- ============================================================
+     HERO — coming-soon stream
+     ============================================================ -->
+<section class="hero">
+  <div class="wrap hero-grid">
+    <div>
+      <p class="kicker" style="margin-bottom:18px">Monitoring stream &middot; Radiation</p>
+      <span class="soon-badge">Coming soon</span>
+      <h1>Background radiation, <em>on the public record.</em></h1>
+      <p class="standfirst">
+        We're preparing a radiation stream for the sensors.AFRICA network: citizen-hosted
+        detectors measuring ambient radiation levels to establish an open, independent baseline
+        for African cities. Background radiation is a normal part of the environment — the point
+        is to measure it continuously, so any change is visible and verifiable. This stream is
+        not live yet.
+      </p>
+      <div class="hero-actions">
+        <a class="btn btn-accent" href="https://docs.google.com/forms/d/e/1FAIpQLSdYwUWsyj5VQggCmpVh4O92VWt6NQ-J6kX-jN7uAa1FOELq0w/viewform" rel="noopener">Notify me when it launches</a>
+        <a class="btn btn-ghost" href="air.html">See the live Air network →</a>
+      </div>
+      <p class="live-note">Air is our only live stream today. Every reading on <a href="air.html">the Air network</a> is real, open and citizen-collected.</p>
+      <span class="proto-badge">Prototype &middot; concept page</span>
+    </div>
+
+    <!-- Planned-metrics panel: honest placeholder, no fake readings -->
+    <aside class="preview-panel" aria-label="Planned radiation metrics — no live data yet">
+      <div class="panel-accent" aria-hidden="true"></div>
+      <div class="panel-top">
+        <span class="panel-title">Planned measurements</span>
+        <span class="panel-status">No live data yet</span>
+      </div>
+      <ul class="metric-list">
+        <li><span class="m">Ambient gamma dose rate</span><span class="v">— · —<span class="u">µSv/h</span></span></li>
+        <li><span class="m">Detector counts</span><span class="v">— · —<span class="u">CPM</span></span></li>
+        <li><span class="m">Rolling local baseline (30-day)</span><span class="v">— · —<span class="u">µSv/h</span></span></li>
+        <li><span class="m">Deviation from baseline</span><span class="v">— · —<span class="u">%</span></span></li>
+        <li><span class="m">Sensor uptime</span><span class="v">— · —<span class="u">%</span></span></li>
+      </ul>
+      <p class="panel-foot">Candidate indicators under evaluation, likely built on Geiger–Müller detectors — calibration and methodology will be published openly before launch.</p>
+    </aside>
+  </div>
+</section>
+
+<!-- ============================================================
+     WHY IT MATTERS — warm-paper reading block
+     ============================================================ -->
+<section class="section paper-section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <p class="kicker">Why radiation, why now</p>
+    <h2 class="display">A baseline you can check beats a rumour you can't</h2>
+    <div class="impact-grid">
+      <div class="impact-prose">
+        <p>
+          Everyone on earth lives with a small, natural dose of background radiation — from rock,
+          soil, building materials and cosmic rays. It is normally low, it varies from place to
+          place, and it is not a cause for alarm. <strong>The problem is not the background; it is
+          the blank spot.</strong> Across most of Africa there is no continuous, publicly
+          accessible record of ambient radiation at all.
+        </p>
+        <p>
+          That absence matters most on the day something is claimed to have changed — near a
+          mining operation, a medical or industrial source, a waste site, or after an incident
+          reported elsewhere. Without an established baseline, neither residents nor journalists
+          can check the claim; with one, a real anomaly shows up as a measurable deviation, and a
+          false alarm can be calmly ruled out. This stream will build that record:
+          <strong>continuous, citizen-hosted dose-rate measurements, published as open data</strong>
+          for independent verification and early warning.
+        </p>
+      </div>
+      <div class="stat-tiles" aria-label="Key figures on background radiation">
+        <div class="stat-tile">
+          <div class="val">≈2.4 mSv</div>
+          <div class="lbl">typical annual dose from natural background radiation, global average (UNSCEAR) — the ordinary level this stream will chart, city by city</div>
+          <div class="bar" aria-hidden="true"><i style="width:24%;background:var(--accent)"></i></div>
+        </div>
+        <div class="stat-tile">
+          <div class="val">0 — for now</div>
+          <div class="lbl">independent, openly published ambient-radiation readings in our network today. That's the gap this stream exists to close.</div>
+          <div class="bar" aria-hidden="true"><i style="width:4%;background:var(--aqi-unhealthy)"></i></div>
+        </div>
+      </div>
+    </div>
+    <p class="paper-credit">Background-dose figure: UNSCEAR (United Nations Scientific Committee on the Effects of Atomic Radiation). This page describes planned work — no radiation readings are being published yet.</p>
+  </div>
+</section>
+
+<!-- ============================================================
+     CTA — stay updated
+     ============================================================ -->
+<section class="cta-section">
+  <div class="cta-inner">
+    <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <h2>Be there when the first reading goes public.</h2>
+    <p>Leave your details and we'll tell you when the radiation stream launches — and how to host a detector and help establish your city's baseline.</p>
+    <a class="btn btn-accent" href="https://docs.google.com/forms/d/e/1FAIpQLSdYwUWsyj5VQggCmpVh4O92VWt6NQ-J6kX-jN7uAa1FOELq0w/viewform" rel="noopener">Stay updated — join the list</a>
+    <p class="cta-proto">Prototype — this is a concept page for the sensors.AFRICA redesign. The radiation stream is not yet live. Meanwhile, <a href="air.html" style="color:var(--text-2)">explore live air data</a>.</p>
+  </div>
+</section>
+
+</main>
+
+<!-- ============================================================
+     FOOTER
+     ============================================================ -->
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+        <p class="footer-mission">A pan-African citizen science initiative using sensors to monitor air, water and sound pollution — giving citizens actionable information about their cities.</p>
+      </div>
+      <div class="footer-col">
+        <h4>Network</h4>
+        <ul>
+          <li><a href="air.html">Air quality</a></li>
+          <li><a href="water.html">Water</a></li>
+          <li><a href="sound.html">Sound</a></li>
+          <li><a href="radiation.html">Radiation</a></li>
+          <li><a href="data.html">Open data</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Community</h4>
+        <ul>
+          <li><a href="stories.html">Stories</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="get-started.html">Get a sensor</a></li>
+          <li><a href="https://twitter.com/sensorsAFRICA/" rel="noopener">Twitter</a></li>
+          <li><a href="https://www.instagram.com/sensorsAFRICA/" rel="noopener">Instagram</a></li>
+          <li><a href="https://medium.com/@sensors.AFRICA" rel="noopener">Medium</a></li>
+          <li><a href="https://github.com/CodeForAfrica/sensors.AFRICA" rel="noopener">GitHub</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Partners</h4>
+        <ul>
+          <li><a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a></li>
+          <li><a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a></li>
+          <li><a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>Incubated by <a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a> · seed-funded by <a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a> · powered by <a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></span>
+      <span>Redesign prototype — the radiation stream is not yet live; this page describes planned work.</span>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/redesign/sound.html
+++ b/redesign/sound.html
@@ -1,0 +1,435 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Sound — coming soon · sensors.AFRICA</title>
+<meta name="description" content="sensors.AFRICA is preparing a sound stream: citizen-hosted sensors measuring noise pollution in African cities and its links to stress, sleep and health. Coming soon — air is our live network today.">
+
+<!-- Fonts: Fraunces (display serif) · Space Grotesk (data) · Inter (body) -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Space+Grotesk:wght@400;500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+
+<style>
+/* ============================================================
+   TOKENS — shared with all subpages, do not diverge
+   ============================================================ */
+:root{
+  --ink:#0c0f16; --ink-2:#141821; --ink-3:#1a1f2b;
+  --paper:#f1eee7; --paper-ink:#17140f;
+  --text:#e9ebf0; --text-2:#9aa2b1; --muted:#6b7280;
+  --hair:rgba(255,255,255,0.09); --hair-strong:rgba(255,255,255,0.16);
+  --aqi-good:#46d17f; --aqi-moderate:#f4c542; --aqi-sensitive:#f5822e;
+  --aqi-unhealthy:#ef5350; --aqi-veryunhealthy:#b06ae0; --aqi-hazardous:#c0466c;
+  --serif:"Fraunces",Georgia,serif;
+  --sans:"Inter",system-ui,-apple-system,sans-serif;
+  --data:"Space Grotesk","Inter",system-ui,sans-serif;
+  --maxw:1200px;
+  /* page accent — SOUND (amber, from the AQI spine) */
+  --accent:#f4c542; --accent-soft:rgba(244,197,66,.10); --accent-hover:#f7d268;
+}
+
+/* ============================================================
+   BASE
+   ============================================================ */
+*{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  background:var(--ink); color:var(--text);
+  font-family:var(--sans); font-size:16px; line-height:1.6;
+  -webkit-font-smoothing:antialiased;
+}
+img{max-width:100%;display:block}
+a{color:inherit}
+:focus-visible{outline:2px solid var(--aqi-moderate);outline-offset:3px;border-radius:2px}
+::selection{background:var(--accent);color:var(--ink)}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
+.kicker{
+  font-family:var(--data);font-size:.75rem;font-weight:500;
+  letter-spacing:.18em;text-transform:uppercase;color:var(--text-2);
+}
+h2.display{
+  font-family:var(--serif);font-weight:600;font-size:clamp(1.7rem,3.4vw,2.6rem);
+  line-height:1.12;letter-spacing:-.01em;margin:10px 0 14px;
+}
+
+/* The AQI spine — a segmented band used as the site's structural accent */
+.aqi-spine{display:flex;height:4px;width:100%}
+.aqi-spine span{flex:1}
+.aqi-spine .s1{background:var(--aqi-good)}
+.aqi-spine .s2{background:var(--aqi-moderate)}
+.aqi-spine .s3{background:var(--aqi-sensitive)}
+.aqi-spine .s4{background:var(--aqi-unhealthy)}
+.aqi-spine .s5{background:var(--aqi-veryunhealthy)}
+.aqi-spine .s6{background:var(--aqi-hazardous)}
+.spine-sm{width:64px;height:4px;margin-bottom:14px}
+
+/* ============================================================
+   HEADER — identical shell across the site
+   ============================================================ */
+.site-header{
+  position:sticky;top:0;z-index:1000;
+  background:rgba(12,15,22,.88);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+  border-bottom:1px solid var(--hair);
+}
+.header-inner{
+  max-width:var(--maxw);margin:0 auto;padding:0 24px;
+  display:flex;align-items:center;justify-content:space-between;gap:20px;height:64px;
+}
+.wordmark{
+  font-family:var(--data);font-weight:700;font-size:1.05rem;letter-spacing:.01em;
+  text-decoration:none;white-space:nowrap;
+}
+.wordmark .dot-africa{color:var(--aqi-good)}
+.main-nav{display:flex;gap:2px;align-items:center;overflow-x:auto}
+.main-nav a{
+  font-family:var(--data);font-size:.82rem;font-weight:500;color:var(--text-2);
+  text-decoration:none;padding:8px 11px;border-radius:6px;white-space:nowrap;
+}
+.main-nav a:hover{color:var(--text);background:var(--ink-3)}
+.main-nav a[aria-current="page"]{color:var(--text);background:var(--ink-3)}
+.main-nav a.live-link{color:var(--text)}
+.main-nav a.live-link::before{
+  content:"";display:inline-block;width:6px;height:6px;border-radius:50%;
+  background:var(--aqi-good);margin-right:7px;vertical-align:1px;
+}
+.nav-cta{
+  font-family:var(--data);font-size:.82rem;font-weight:700;text-decoration:none;
+  color:var(--ink);background:var(--aqi-good);padding:9px 16px;border-radius:999px;white-space:nowrap;
+}
+.nav-cta:hover{background:#5fdd92}
+
+/* ============================================================
+   HERO — coming-soon data-stream layout (shared template)
+   ============================================================ */
+.hero{position:relative;overflow:hidden;border-bottom:1px solid var(--hair)}
+.hero::before{ /* faint accent wash */
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:
+    radial-gradient(52rem 30rem at 78% -10%, var(--accent-soft), transparent 60%),
+    radial-gradient(44rem 26rem at 8% 110%, rgba(70,209,127,.05), transparent 60%);
+}
+.hero-grid{
+  position:relative;display:grid;grid-template-columns:minmax(0,1.15fr) minmax(0,.85fr);
+  gap:56px;align-items:center;padding:76px 0 68px;
+}
+.hero h1{
+  font-family:var(--serif);font-weight:640;font-variation-settings:"opsz" 100;
+  font-size:clamp(2.5rem,5.4vw,4.3rem);line-height:1.04;letter-spacing:-.015em;
+}
+.hero h1 em{font-style:italic;font-weight:520;color:var(--accent)}
+.hero .standfirst{margin-top:22px;font-size:1.08rem;color:var(--text-2);max-width:52ch}
+.hero-actions{margin-top:30px;display:flex;gap:14px;flex-wrap:wrap;align-items:center}
+.btn{
+  font-family:var(--data);font-weight:700;font-size:.92rem;text-decoration:none;
+  padding:13px 24px;border-radius:999px;display:inline-block;
+}
+.btn-accent{background:var(--accent);color:var(--ink)}
+.btn-accent:hover{background:var(--accent-hover)}
+.btn-ghost{color:var(--text);border:1px solid var(--hair-strong)}
+.btn-ghost:hover{border-color:var(--text-2)}
+.proto-badge{
+  display:inline-flex;align-items:center;gap:7px;margin-top:26px;
+  font-family:var(--data);font-size:.68rem;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--muted);border:1px solid var(--hair);border-radius:999px;padding:5px 12px;
+}
+.proto-badge::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--aqi-moderate)}
+
+/* honest status badge — this stream is not live yet */
+.soon-badge{
+  display:inline-flex;align-items:center;gap:9px;margin-bottom:22px;
+  font-family:var(--data);font-size:.72rem;font-weight:700;letter-spacing:.16em;text-transform:uppercase;
+  color:var(--accent);border:1px solid var(--accent);border-radius:999px;padding:7px 16px;
+}
+.soon-badge::before{content:"";width:7px;height:7px;border-radius:50%;border:2px solid var(--accent)}
+.live-note{margin-top:14px;font-family:var(--data);font-size:.8rem;color:var(--muted)}
+.live-note a{color:var(--text-2)}
+.live-note a:hover{color:var(--text)}
+
+/* Preview panel — planned metrics, deliberately shown without data */
+.preview-panel{
+  position:relative;background:var(--ink-2);border:1px solid var(--hair-strong);
+  border-radius:16px;padding:26px 28px 24px;box-shadow:0 24px 60px rgba(0,0,0,.45);
+}
+.preview-panel .panel-accent{
+  position:absolute;top:0;left:0;right:0;height:4px;
+  border-radius:16px 16px 0 0;background:var(--accent);
+}
+.panel-top{display:flex;justify-content:space-between;align-items:baseline;gap:12px;margin-top:6px}
+.panel-title{font-family:var(--serif);font-size:1.4rem;font-weight:600}
+.panel-status{
+  font-family:var(--data);font-size:.66rem;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--muted);border:1px solid var(--hair);border-radius:999px;padding:4px 11px;white-space:nowrap;
+}
+.metric-list{list-style:none;margin-top:20px}
+.metric-list li{
+  display:flex;justify-content:space-between;align-items:baseline;gap:14px;
+  padding:11px 0;border-bottom:1px solid var(--hair);
+  font-family:var(--data);font-size:.88rem;
+}
+.metric-list li:last-child{border-bottom:0}
+.metric-list .m{color:var(--text-2)}
+.metric-list .v{color:var(--muted);font-variant-numeric:tabular-nums;letter-spacing:.08em}
+.metric-list .u{color:var(--muted);font-size:.72rem;margin-left:6px}
+.panel-foot{
+  margin-top:14px;padding-top:14px;border-top:1px solid var(--hair);
+  font-family:var(--data);font-size:.72rem;color:var(--muted);
+}
+
+/* ============================================================
+   PAPER SECTION — why it matters (warm reading surface)
+   ============================================================ */
+.section{padding:84px 0}
+.paper-section{background:var(--paper);color:var(--paper-ink)}
+.paper-section .kicker{color:#6d675c}
+.paper-section h2.display{color:var(--paper-ink)}
+.impact-grid{display:grid;grid-template-columns:1.1fr .9fr;gap:56px;align-items:start;margin-top:20px}
+.impact-prose{font-family:var(--serif);font-size:1.16rem;line-height:1.72;color:#2c2820;font-weight:420}
+.impact-prose p+p{margin-top:1.1em}
+.impact-prose strong{font-weight:640;color:var(--paper-ink)}
+.stat-tiles{display:grid;grid-template-columns:1fr;gap:14px}
+.stat-tile{background:#fff;border:1px solid #e2ddd1;border-radius:12px;padding:20px 20px 18px}
+.stat-tile .val{font-family:var(--data);font-weight:700;font-size:2.1rem;line-height:1.1;color:var(--paper-ink)}
+.stat-tile .lbl{font-size:.8rem;color:#6d675c;margin-top:6px;line-height:1.45}
+.stat-tile .bar{height:4px;border-radius:2px;background:#ece8dd;margin-top:14px;overflow:hidden}
+.stat-tile .bar i{display:block;height:100%;border-radius:2px}
+.paper-credit{margin-top:34px;font-family:var(--data);font-size:.74rem;color:#8a8375}
+
+/* ============================================================
+   CTA — notify me / stay updated
+   ============================================================ */
+.cta-section{position:relative;overflow:hidden;border-top:1px solid var(--hair)}
+.cta-section::before{
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:radial-gradient(50rem 26rem at 50% 120%, var(--accent-soft), transparent 65%);
+}
+.cta-inner{position:relative;text-align:center;padding:96px 24px;max-width:760px;margin:0 auto}
+.cta-inner h2{
+  font-family:var(--serif);font-weight:640;font-size:clamp(2rem,4.4vw,3.3rem);
+  line-height:1.08;letter-spacing:-.015em;
+}
+.cta-inner p{margin:20px auto 32px;color:var(--text-2);max-width:46ch}
+.cta-inner .aqi-spine{width:120px;margin:0 auto 28px}
+.cta-proto{margin-top:30px;font-family:var(--data);font-size:.74rem;color:var(--muted)}
+
+/* ============================================================
+   FOOTER — identical shell across the site
+   ============================================================ */
+.site-footer{background:#080a10;border-top:1px solid var(--hair);padding:64px 0 40px}
+.footer-grid{display:grid;grid-template-columns:1.4fr 1fr 1fr 1fr;gap:40px}
+.footer-mission{font-size:.9rem;color:var(--text-2);margin-top:14px;max-width:38ch}
+.footer-col h4{
+  font-family:var(--data);font-size:.66rem;font-weight:700;letter-spacing:.16em;
+  text-transform:uppercase;color:var(--muted);margin-bottom:16px;
+}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:9px}
+.footer-col a{font-size:.88rem;color:var(--text-2);text-decoration:none}
+.footer-col a:hover{color:var(--text)}
+.footer-bottom{
+  margin-top:52px;padding-top:22px;border-top:1px solid var(--hair);
+  display:flex;justify-content:space-between;gap:14px;flex-wrap:wrap;
+  font-family:var(--data);font-size:.74rem;color:var(--muted);
+}
+.footer-bottom a{color:var(--text-2)}
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width:1020px){
+  .footer-grid{grid-template-columns:1fr 1fr}
+  .impact-grid{grid-template-columns:1fr;gap:36px}
+}
+@media (max-width:820px){
+  .hero-grid{grid-template-columns:1fr;gap:40px;padding:56px 0}
+  .main-nav{display:none}
+}
+@media (max-width:600px){
+  .footer-grid{grid-template-columns:1fr}
+  .section{padding:60px 0}
+}
+
+/* ============================================================
+   REDUCED MOTION
+   ============================================================ */
+@media (prefers-reduced-motion:reduce){
+  html{scroll-behavior:auto}
+}
+</style>
+</head>
+<body>
+
+<!-- ============================================================
+     HEADER
+     ============================================================ -->
+<header class="site-header">
+  <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+  <div class="header-inner">
+    <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+    <nav class="main-nav" aria-label="Primary">
+      <a class="live-link" href="air.html">Air</a>
+      <a href="water.html">Water</a>
+      <a href="sound.html" aria-current="page">Sound</a>
+      <a href="radiation.html">Radiation</a>
+      <a href="data.html">Data</a>
+      <a href="stories.html">Stories</a>
+      <a href="about.html">About</a>
+    </nav>
+    <a class="nav-cta" href="get-started.html">Get a sensor</a>
+  </div>
+</header>
+
+<main>
+
+<!-- ============================================================
+     HERO — coming-soon stream
+     ============================================================ -->
+<section class="hero">
+  <div class="wrap hero-grid">
+    <div>
+      <p class="kicker" style="margin-bottom:18px">Monitoring stream &middot; Sound</p>
+      <span class="soon-badge">Coming soon</span>
+      <h1>The city is loud. <em>Soon we'll have the numbers.</em></h1>
+      <p class="standfirst">
+        We're preparing a sound stream for the sensors.AFRICA network: citizen-hosted sensors
+        measuring noise pollution block by block — near flight paths, highways, markets, bars and
+        construction sites — and tracing its links to stress, broken sleep and long-term health.
+        This stream is not live yet — we're publishing our plans openly while we build it.
+      </p>
+      <div class="hero-actions">
+        <a class="btn btn-accent" href="https://docs.google.com/forms/d/e/1FAIpQLSdYwUWsyj5VQggCmpVh4O92VWt6NQ-J6kX-jN7uAa1FOELq0w/viewform" rel="noopener">Notify me when it launches</a>
+        <a class="btn btn-ghost" href="air.html">See the live Air network →</a>
+      </div>
+      <p class="live-note">Air is our only live stream today. Every reading on <a href="air.html">the Air network</a> is real, open and citizen-collected.</p>
+      <span class="proto-badge">Prototype &middot; concept page</span>
+    </div>
+
+    <!-- Planned-metrics panel: honest placeholder, no fake readings -->
+    <aside class="preview-panel" aria-label="Planned noise metrics — no live data yet">
+      <div class="panel-accent" aria-hidden="true"></div>
+      <div class="panel-top">
+        <span class="panel-title">Planned measurements</span>
+        <span class="panel-status">No live data yet</span>
+      </div>
+      <ul class="metric-list">
+        <li><span class="m">Average level, daytime (L<sub>Aeq,day</sub>)</span><span class="v">— · —<span class="u">dB(A)</span></span></li>
+        <li><span class="m">Average level, night (L<sub>Aeq,night</sub>)</span><span class="v">— · —<span class="u">dB(A)</span></span></li>
+        <li><span class="m">Peak events (L<sub>Amax</sub>)</span><span class="v">— · —<span class="u">dB(A)</span></span></li>
+        <li><span class="m">Events above threshold / night</span><span class="v">— · —<span class="u">count</span></span></li>
+        <li><span class="m">Quiet-hours compliance</span><span class="v">— · —<span class="u">%</span></span></li>
+      </ul>
+      <p class="panel-foot">Candidate indicators under evaluation — levels only, never recordings. The methodology will be published openly before launch.</p>
+    </aside>
+  </div>
+</section>
+
+<!-- ============================================================
+     WHY IT MATTERS — warm-paper reading block
+     ============================================================ -->
+<section class="section paper-section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <p class="kicker">Why sound, why now</p>
+    <h2 class="display">Noise is the pollution everyone hears and no one measures</h2>
+    <div class="impact-grid">
+      <div class="impact-prose">
+        <p>
+          Noise is more than a nuisance. Sustained exposure is linked to <strong>chronic stress,
+          sleep disturbance, poorer concentration in schoolchildren and elevated cardiovascular
+          risk</strong> — the World Health Organization ranks environmental noise among the top
+          environmental burdens on health in the regions where it has been studied. In western
+          Europe alone, WHO estimates traffic noise costs more than a million healthy life-years
+          every year.
+        </p>
+        <p>
+          African cities are among the most vibrant — and often the loudest — on earth, yet almost
+          none of that exposure is measured, and even less of it is public. When a resident
+          complains about the generator next door or the new flight path overhead, there is rarely
+          a number to point to. This stream will put one on the record: <strong>calibrated,
+          citizen-hosted noise levels, mapped block by block and published as open data</strong> —
+          measuring levels, not conversations.
+        </p>
+      </div>
+      <div class="stat-tiles" aria-label="Key figures on noise pollution and health">
+        <div class="stat-tile">
+          <div class="val">1,000,000+</div>
+          <div class="lbl">healthy life-years lost to traffic noise every year in western Europe alone (WHO) — African cities remain largely unmeasured</div>
+          <div class="bar" aria-hidden="true"><i style="width:78%;background:var(--accent)"></i></div>
+        </div>
+        <div class="stat-tile">
+          <div class="val">0 — for now</div>
+          <div class="lbl">independent, openly published noise readings in our network today. That's the gap this stream exists to close.</div>
+          <div class="bar" aria-hidden="true"><i style="width:4%;background:var(--aqi-unhealthy)"></i></div>
+        </div>
+      </div>
+    </div>
+    <p class="paper-credit">Health framing and burden estimate: World Health Organization environmental-noise guidance. This page describes planned work — no sound readings are being published yet.</p>
+  </div>
+</section>
+
+<!-- ============================================================
+     CTA — stay updated
+     ============================================================ -->
+<section class="cta-section">
+  <div class="cta-inner">
+    <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <h2>Be there when the first reading goes public.</h2>
+    <p>Leave your details and we'll tell you when the sound stream launches — and how to host a noise sensor on your street, school or office.</p>
+    <a class="btn btn-accent" href="https://docs.google.com/forms/d/e/1FAIpQLSdYwUWsyj5VQggCmpVh4O92VWt6NQ-J6kX-jN7uAa1FOELq0w/viewform" rel="noopener">Stay updated — join the list</a>
+    <p class="cta-proto">Prototype — this is a concept page for the sensors.AFRICA redesign. The sound stream is not yet live. Meanwhile, <a href="air.html" style="color:var(--text-2)">explore live air data</a>.</p>
+  </div>
+</section>
+
+</main>
+
+<!-- ============================================================
+     FOOTER
+     ============================================================ -->
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+        <p class="footer-mission">A pan-African citizen science initiative using sensors to monitor air, water and sound pollution — giving citizens actionable information about their cities.</p>
+      </div>
+      <div class="footer-col">
+        <h4>Network</h4>
+        <ul>
+          <li><a href="air.html">Air quality</a></li>
+          <li><a href="water.html">Water</a></li>
+          <li><a href="sound.html">Sound</a></li>
+          <li><a href="radiation.html">Radiation</a></li>
+          <li><a href="data.html">Open data</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Community</h4>
+        <ul>
+          <li><a href="stories.html">Stories</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="get-started.html">Get a sensor</a></li>
+          <li><a href="https://twitter.com/sensorsAFRICA/" rel="noopener">Twitter</a></li>
+          <li><a href="https://www.instagram.com/sensorsAFRICA/" rel="noopener">Instagram</a></li>
+          <li><a href="https://medium.com/@sensors.AFRICA" rel="noopener">Medium</a></li>
+          <li><a href="https://github.com/CodeForAfrica/sensors.AFRICA" rel="noopener">GitHub</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Partners</h4>
+        <ul>
+          <li><a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a></li>
+          <li><a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a></li>
+          <li><a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>Incubated by <a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a> · seed-funded by <a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a> · powered by <a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></span>
+      <span>Redesign prototype — the sound stream is not yet live; this page describes planned work.</span>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/redesign/stories.html
+++ b/redesign/stories.html
@@ -1,0 +1,760 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Stories — sensors.AFRICA</title>
+<meta name="description" content="Data as testimony. Journalism, investigations and dispatches built on sensors.AFRICA citizen-science data — hyper-local pollution evidence from African cities.">
+
+<!-- Fonts: Fraunces (display serif) · Space Grotesk (data) · Inter (body) -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Space+Grotesk:wght@400;500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+
+<style>
+/* ============================================================
+   TOKENS — shared with all subpages, do not diverge
+   ============================================================ */
+:root{
+  --ink:#0c0f16; --ink-2:#141821; --ink-3:#1a1f2b;
+  --paper:#f1eee7; --paper-ink:#17140f;
+  --text:#e9ebf0; --text-2:#9aa2b1; --muted:#6b7280;
+  --hair:rgba(255,255,255,0.09); --hair-strong:rgba(255,255,255,0.16);
+  --aqi-good:#46d17f; --aqi-moderate:#f4c542; --aqi-sensitive:#f5822e;
+  --aqi-unhealthy:#ef5350; --aqi-veryunhealthy:#b06ae0; --aqi-hazardous:#c0466c;
+  --serif:"Fraunces",Georgia,serif;
+  --sans:"Inter",system-ui,-apple-system,sans-serif;
+  --data:"Space Grotesk","Inter",system-ui,sans-serif;
+  --maxw:1200px;
+}
+
+/* ============================================================
+   BASE
+   ============================================================ */
+*{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  background:var(--ink); color:var(--text);
+  font-family:var(--sans); font-size:16px; line-height:1.6;
+  -webkit-font-smoothing:antialiased;
+}
+img{max-width:100%;display:block}
+a{color:inherit}
+:focus-visible{outline:2px solid var(--aqi-moderate);outline-offset:3px;border-radius:2px}
+::selection{background:var(--aqi-sensitive);color:var(--ink)}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
+.kicker{
+  font-family:var(--data);font-size:.75rem;font-weight:500;
+  letter-spacing:.18em;text-transform:uppercase;color:var(--text-2);
+}
+.section-head{display:flex;align-items:baseline;justify-content:space-between;gap:16px;flex-wrap:wrap;margin-bottom:8px}
+h2.display{
+  font-family:var(--serif);font-weight:600;font-size:clamp(1.7rem,3.4vw,2.6rem);
+  line-height:1.12;letter-spacing:-.01em;margin:10px 0 14px;
+}
+.lede{color:var(--text-2);max-width:56ch}
+.section{padding:84px 0}
+.btn{
+  font-family:var(--data);font-weight:700;font-size:.92rem;text-decoration:none;
+  padding:13px 24px;border-radius:999px;display:inline-block;
+}
+.btn-primary{background:var(--aqi-good);color:var(--ink)}
+.btn-primary:hover{background:#5fdd92}
+.btn-ghost{color:var(--text);border:1px solid var(--hair-strong)}
+.btn-ghost:hover{border-color:var(--text-2)}
+.proto-badge{
+  display:inline-flex;align-items:center;gap:7px;margin-top:26px;
+  font-family:var(--data);font-size:.68rem;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--muted);border:1px solid var(--hair);border-radius:999px;padding:5px 12px;
+}
+.proto-badge::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--aqi-moderate)}
+
+/* The AQI spine — a segmented band used as the page's structural accent */
+.aqi-spine{display:flex;height:4px;width:100%}
+.aqi-spine span{flex:1}
+.aqi-spine .s1{background:var(--aqi-good)}
+.aqi-spine .s2{background:var(--aqi-moderate)}
+.aqi-spine .s3{background:var(--aqi-sensitive)}
+.aqi-spine .s4{background:var(--aqi-unhealthy)}
+.aqi-spine .s5{background:var(--aqi-veryunhealthy)}
+.aqi-spine .s6{background:var(--aqi-hazardous)}
+.spine-sm{width:64px;height:4px;margin-bottom:14px}
+
+/* ============================================================
+   HEADER
+   ============================================================ */
+.site-header{
+  position:sticky;top:0;z-index:1000;
+  background:rgba(12,15,22,.88);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+  border-bottom:1px solid var(--hair);
+}
+.header-inner{
+  max-width:var(--maxw);margin:0 auto;padding:0 24px;
+  display:flex;align-items:center;justify-content:space-between;gap:20px;height:64px;
+}
+.wordmark{
+  font-family:var(--data);font-weight:700;font-size:1.05rem;letter-spacing:.01em;
+  text-decoration:none;white-space:nowrap;
+}
+.wordmark .dot-africa{color:var(--aqi-good)}
+.main-nav{display:flex;gap:2px;align-items:center;overflow-x:auto}
+.main-nav a{
+  font-family:var(--data);font-size:.82rem;font-weight:500;color:var(--text-2);
+  text-decoration:none;padding:8px 11px;border-radius:6px;white-space:nowrap;
+}
+.main-nav a:hover{color:var(--text);background:var(--ink-3)}
+.main-nav a.live-link{color:var(--text)}
+.main-nav a.live-link::before{
+  content:"";display:inline-block;width:6px;height:6px;border-radius:50%;
+  background:var(--aqi-good);margin-right:7px;vertical-align:1px;
+}
+.main-nav a.active{color:var(--text);background:var(--ink-3)}
+.nav-cta{
+  font-family:var(--data);font-size:.82rem;font-weight:700;text-decoration:none;
+  color:var(--ink);background:var(--aqi-good);padding:9px 16px;border-radius:999px;white-space:nowrap;
+}
+.nav-cta:hover{background:#5fdd92}
+
+/* ============================================================
+   EDITORIAL MASTHEAD — the newsroom front page
+   ============================================================ */
+.masthead{position:relative;overflow:hidden;border-bottom:1px solid var(--hair)}
+.masthead::before{
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:
+    radial-gradient(52rem 30rem at 82% -12%, rgba(176,106,224,.08), transparent 60%),
+    radial-gradient(44rem 26rem at 4% 115%, rgba(245,130,46,.07), transparent 60%);
+}
+.masthead-inner{position:relative;padding:78px 0 58px;text-align:center}
+.masthead .rubric{
+  font-family:var(--data);font-size:.75rem;font-weight:500;letter-spacing:.22em;
+  text-transform:uppercase;color:var(--text-2);
+}
+.masthead h1{
+  font-family:var(--serif);font-weight:640;font-variation-settings:"opsz" 100;
+  font-size:clamp(3rem,7.5vw,5.4rem);line-height:1.02;letter-spacing:-.018em;margin:18px 0 6px;
+}
+.masthead .strap{
+  font-family:var(--serif);font-style:italic;font-weight:480;
+  font-size:clamp(1.2rem,2.4vw,1.65rem);color:var(--aqi-sensitive);
+}
+.masthead .standfirst{
+  margin:22px auto 0;max-width:62ch;color:var(--text-2);font-size:1.05rem;
+}
+.masthead-rule{
+  display:flex;align-items:center;gap:18px;max-width:520px;margin:30px auto 0;
+}
+.masthead-rule::before,.masthead-rule::after{content:"";flex:1;height:1px;background:var(--hair-strong)}
+.masthead-rule .edition{
+  font-family:var(--data);font-size:.68rem;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);white-space:nowrap;
+}
+
+/* ============================================================
+   FEATURED LEAD STORY
+   ============================================================ */
+.lead-story{
+  display:grid;grid-template-columns:minmax(0,1.05fr) minmax(0,.95fr);
+  background:var(--ink-2);border:1px solid var(--hair-strong);border-radius:18px;
+  overflow:hidden;text-decoration:none;margin-top:38px;
+  transition:transform .2s ease,border-color .2s ease;
+}
+.lead-story:hover{transform:translateY(-3px);border-color:var(--text-2)}
+.lead-visual{position:relative;min-height:360px;overflow:hidden}
+.lead-visual svg{position:absolute;inset:0;width:100%;height:100%}
+.lead-body{padding:42px 44px 40px;display:flex;flex-direction:column;justify-content:center}
+.tagline-row{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:16px}
+.story-tag{
+  font-family:var(--data);font-size:.64rem;font-weight:700;letter-spacing:.16em;
+  text-transform:uppercase;border-radius:999px;padding:4px 11px;border:1px solid var(--hair-strong);color:var(--text-2);
+}
+.story-tag.t-climate{color:var(--aqi-moderate);border-color:rgba(244,197,66,.4)}
+.story-tag.t-air{color:var(--aqi-sensitive);border-color:rgba(245,130,46,.4)}
+.story-tag.t-health{color:var(--aqi-unhealthy);border-color:rgba(239,83,80,.4)}
+.story-tag.t-invest{color:var(--aqi-veryunhealthy);border-color:rgba(176,106,224,.45)}
+.story-tag.t-real{color:var(--aqi-good);border-color:rgba(70,209,127,.4)}
+.story-place{font-family:var(--data);font-size:.72rem;letter-spacing:.12em;text-transform:uppercase;color:var(--muted)}
+.lead-body h2{
+  font-family:var(--serif);font-weight:620;font-size:clamp(1.7rem,3vw,2.5rem);
+  line-height:1.12;letter-spacing:-.012em;margin-bottom:16px;
+}
+.lead-body .deck{color:var(--text-2);font-size:1.02rem;max-width:52ch}
+.byline{
+  margin-top:22px;font-family:var(--data);font-size:.76rem;color:var(--muted);
+  display:flex;gap:10px;flex-wrap:wrap;align-items:center;
+}
+.byline .sep{opacity:.5}
+.read-cue{margin-top:20px;font-family:var(--data);font-size:.82rem;font-weight:700;color:var(--aqi-good)}
+.lead-story:hover .read-cue{text-decoration:underline}
+
+/* ============================================================
+   STORY GRID — the magazine index
+   ============================================================ */
+.index-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:20px}
+.story-card{
+  display:flex;flex-direction:column;text-decoration:none;
+  background:var(--ink-2);border:1px solid var(--hair);border-radius:14px;overflow:hidden;
+  transition:transform .2s ease,border-color .2s ease;
+}
+.story-card:hover{transform:translateY(-3px);border-color:var(--hair-strong)}
+.story-visual{height:148px;position:relative;overflow:hidden}
+.story-visual svg{width:100%;height:100%;display:block}
+.story-body{padding:22px 22px 24px;display:flex;flex-direction:column;flex:1}
+.story-card h3{font-family:var(--serif);font-size:1.26rem;font-weight:600;line-height:1.25;margin-bottom:10px}
+.story-card .deck{font-size:.88rem;color:var(--text-2);flex:1}
+.story-card .tagline-row{margin-bottom:12px}
+.story-card .byline{margin-top:16px}
+.story-card .read-cue{margin-top:12px;font-size:.78rem}
+.story-card:hover .read-cue{text-decoration:underline}
+
+/* Medium CTA band */
+.medium-band{
+  margin-top:44px;background:var(--ink-2);border:1px solid var(--hair-strong);border-radius:16px;
+  padding:34px 38px;display:flex;align-items:center;justify-content:space-between;gap:24px;flex-wrap:wrap;
+}
+.medium-band h3{font-family:var(--serif);font-size:1.5rem;font-weight:600;margin-bottom:6px}
+.medium-band p{color:var(--text-2);font-size:.92rem;max-width:52ch}
+.medium-mark{
+  font-family:var(--serif);font-weight:700;font-style:italic;font-size:1.4rem;letter-spacing:-.02em;
+  width:52px;height:52px;border-radius:50%;background:var(--paper);color:var(--paper-ink);
+  display:flex;align-items:center;justify-content:center;flex:none;
+}
+.medium-left{display:flex;align-items:center;gap:20px}
+
+/* ============================================================
+   STAY UPDATED — newsletter + trailheads
+   ============================================================ */
+.updates-section{background:var(--ink-2);border-top:1px solid var(--hair);border-bottom:1px solid var(--hair)}
+.updates-grid{display:grid;grid-template-columns:1.1fr .9fr;gap:56px;align-items:start;margin-top:26px}
+.newsletter-card{
+  background:var(--ink);border:1px solid var(--hair-strong);border-radius:16px;padding:30px 30px 26px;
+}
+.newsletter-card h3{font-family:var(--serif);font-size:1.4rem;font-weight:600;margin-bottom:8px}
+.newsletter-card p{color:var(--text-2);font-size:.9rem;max-width:46ch}
+.newsletter-form{display:flex;gap:10px;margin-top:20px;flex-wrap:wrap}
+.newsletter-form input[type="email"]{
+  flex:1;min-width:220px;background:var(--ink-3);border:1px solid var(--hair-strong);border-radius:999px;
+  color:var(--text);font-family:var(--data);font-size:.9rem;padding:12px 20px;
+}
+.newsletter-form input[type="email"]::placeholder{color:var(--muted)}
+.newsletter-form button{
+  font-family:var(--data);font-weight:700;font-size:.9rem;border:0;cursor:pointer;
+  background:var(--aqi-good);color:var(--ink);padding:12px 24px;border-radius:999px;
+}
+.newsletter-form button:hover{background:#5fdd92}
+.newsletter-note{margin-top:14px;font-family:var(--data);font-size:.72rem;color:var(--muted)}
+.newsletter-confirm{margin-top:14px;font-family:var(--data);font-size:.82rem;color:var(--aqi-good);display:none}
+.trailheads{display:grid;gap:14px}
+.trail-card{
+  display:block;text-decoration:none;background:var(--ink);border:1px solid var(--hair);
+  border-radius:14px;padding:22px 24px;position:relative;
+  transition:transform .2s ease,border-color .2s ease;
+}
+.trail-card:hover{transform:translateY(-2px);border-color:var(--hair-strong)}
+.trail-card h4{font-family:var(--serif);font-size:1.15rem;font-weight:600;margin:6px 0 6px}
+.trail-card p{font-size:.86rem;color:var(--text-2)}
+.trail-card .go{
+  position:absolute;right:20px;top:24px;font-family:var(--data);color:var(--muted);
+  transition:transform .2s ease,color .2s ease;
+}
+.trail-card:hover .go{transform:translateX(4px);color:var(--text)}
+
+/* ============================================================
+   FOOTER
+   ============================================================ */
+.site-footer{background:#080a10;border-top:1px solid var(--hair);padding:64px 0 40px}
+.footer-grid{display:grid;grid-template-columns:1.4fr 1fr 1fr 1fr;gap:40px}
+.footer-mission{font-size:.9rem;color:var(--text-2);margin-top:14px;max-width:38ch}
+.footer-col h4{
+  font-family:var(--data);font-size:.66rem;font-weight:700;letter-spacing:.16em;
+  text-transform:uppercase;color:var(--muted);margin-bottom:16px;
+}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:9px}
+.footer-col a{font-size:.88rem;color:var(--text-2);text-decoration:none}
+.footer-col a:hover{color:var(--text)}
+.footer-bottom{
+  margin-top:52px;padding-top:22px;border-top:1px solid var(--hair);
+  display:flex;justify-content:space-between;gap:14px;flex-wrap:wrap;
+  font-family:var(--data);font-size:.74rem;color:var(--muted);
+}
+.footer-bottom a{color:var(--text-2)}
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width:1020px){
+  .index-grid{grid-template-columns:1fr 1fr}
+  .footer-grid{grid-template-columns:1fr 1fr}
+  .updates-grid{grid-template-columns:1fr;gap:32px}
+  .lead-story{grid-template-columns:1fr}
+  .lead-visual{min-height:240px}
+  .lead-body{padding:32px 30px 34px}
+}
+@media (max-width:820px){
+  .main-nav{display:none}
+  .masthead-inner{padding:58px 0 46px}
+}
+@media (max-width:600px){
+  .index-grid,.footer-grid{grid-template-columns:1fr}
+  .section{padding:60px 0}
+  .medium-band{padding:26px 24px}
+}
+
+/* ============================================================
+   REDUCED MOTION
+   ============================================================ */
+@media (prefers-reduced-motion:reduce){
+  html{scroll-behavior:auto}
+  .story-card,.lead-story,.trail-card,.trail-card .go{transition:none}
+  .story-card:hover,.lead-story:hover,.trail-card:hover{transform:none}
+}
+</style>
+</head>
+<body>
+
+<!-- ============================================================
+     HEADER
+     ============================================================ -->
+<header class="site-header">
+  <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+  <div class="header-inner">
+    <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+    <nav class="main-nav" aria-label="Primary">
+      <a class="live-link" href="air.html">Air</a>
+      <a href="water.html">Water</a>
+      <a href="sound.html">Sound</a>
+      <a href="radiation.html">Radiation</a>
+      <a href="data.html">Data</a>
+      <a class="active" aria-current="page" href="stories.html">Stories</a>
+      <a href="about.html">About</a>
+    </nav>
+    <a class="nav-cta" href="get-started.html">Get a sensor</a>
+  </div>
+</header>
+
+<main>
+
+<!-- ============================================================
+     EDITORIAL MASTHEAD
+     ============================================================ -->
+<section class="masthead">
+  <div class="wrap masthead-inner">
+    <p class="rubric">The sensors.AFRICA journal</p>
+    <h1>Stories</h1>
+    <p class="strap">Data as testimony.</p>
+    <p class="standfirst">
+      Every sensor on the network is a witness. Here, journalists, watchdogs and the citizens
+      who host the hardware turn its readings into evidence — investigations, health reporting
+      and dispatches from the streets where the data is made.
+    </p>
+    <div class="masthead-rule" aria-hidden="true">
+      <span class="edition">Reporting from the network · Air · Health · Climate</span>
+    </div>
+    <span class="proto-badge">Prototype &middot; illustrative story listings</span>
+  </div>
+</section>
+
+<!-- ============================================================
+     FEATURED LEAD STORY — StormWatch (real initiative)
+     ============================================================ -->
+<section class="section" style="padding-bottom:0">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">Lead story</p>
+        <h2 class="display">The front page</h2>
+      </div>
+      <p class="lede">One featured initiative, then the index. Every listing links to our open reporting on Medium.</p>
+    </div>
+
+    <a class="lead-story" href="https://medium.com/@sensors.AFRICA" rel="noopener">
+      <div class="lead-visual" aria-hidden="true">
+        <svg viewBox="0 0 600 420" preserveAspectRatio="xMidYMid slice" role="presentation">
+          <defs>
+            <linearGradient id="lv-sky" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stop-color="#0e1320"></stop>
+              <stop offset="1" stop-color="#141d2c"></stop>
+            </linearGradient>
+            <linearGradient id="lv-water" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stop-color="#173247"></stop>
+              <stop offset="1" stop-color="#0d1826"></stop>
+            </linearGradient>
+          </defs>
+          <rect width="600" height="420" fill="url(#lv-sky)"></rect>
+          <!-- storm cell -->
+          <g opacity="0.9">
+            <circle cx="440" cy="96" r="26" fill="none" stroke="var(--aqi-moderate)" stroke-width="2.5" opacity="0.85"></circle>
+            <circle cx="440" cy="96" r="48" fill="none" stroke="var(--aqi-moderate)" stroke-width="1.5" opacity="0.45"></circle>
+            <circle cx="440" cy="96" r="72" fill="none" stroke="var(--aqi-moderate)" stroke-width="1" opacity="0.22"></circle>
+            <path d="M446,72 L430,100 L442,100 L432,124" fill="none" stroke="var(--aqi-moderate)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"></path>
+          </g>
+          <!-- rain hatches -->
+          <g stroke="#4fa8d8" stroke-width="1.5" opacity="0.35" stroke-linecap="round">
+            <line x1="330" y1="150" x2="318" y2="186"></line>
+            <line x1="368" y1="158" x2="356" y2="194"></line>
+            <line x1="406" y1="166" x2="394" y2="202"></line>
+            <line x1="490" y1="152" x2="478" y2="188"></line>
+            <line x1="528" y1="142" x2="516" y2="178"></line>
+          </g>
+          <!-- lake -->
+          <path d="M0,268 Q90,240 180,258 T360,250 T600,262 L600,420 L0,420 Z" fill="url(#lv-water)"></path>
+          <g stroke="#4fa8d8" opacity="0.4" fill="none" stroke-width="1.5" stroke-linecap="round">
+            <path d="M40,308 q20,-8 40,0 t40,0"></path>
+            <path d="M210,336 q20,-8 40,0 t40,0"></path>
+            <path d="M420,318 q20,-8 40,0 t40,0"></path>
+            <path d="M110,376 q20,-8 40,0 t40,0"></path>
+            <path d="M330,384 q20,-8 40,0 t40,0"></path>
+          </g>
+          <!-- fishing boat -->
+          <g>
+            <path d="M120,300 L196,300 L182,318 L134,318 Z" fill="#e9ebf0" opacity="0.85"></path>
+            <line x1="158" y1="300" x2="158" y2="252" stroke="#e9ebf0" stroke-width="2.5" opacity="0.85"></line>
+            <path d="M158,252 L192,288 L158,288 Z" fill="var(--aqi-sensitive)" opacity="0.9"></path>
+          </g>
+          <!-- warning beacon on shore -->
+          <g>
+            <line x1="520" y1="264" x2="520" y2="216" stroke="#e9ebf0" stroke-width="2.5" opacity="0.8"></line>
+            <circle cx="520" cy="208" r="7" fill="var(--aqi-unhealthy)"></circle>
+            <circle cx="520" cy="208" r="14" fill="none" stroke="var(--aqi-unhealthy)" stroke-width="1.5" opacity="0.5"></circle>
+          </g>
+        </svg>
+      </div>
+      <div class="lead-body">
+        <div class="tagline-row">
+          <span class="story-tag t-real">Real initiative</span>
+          <span class="story-tag t-climate">Climate</span>
+          <span class="story-place">Lake Victoria · Kenya · Tanzania · Uganda</span>
+        </div>
+        <h2>StormWatch: an early warning before the lake turns</h2>
+        <p class="deck">
+          Lake Victoria is one of the deadliest stretches of water on Earth for the people who
+          work it — thousands of fishers are lost to sudden night storms every year. StormWatch
+          pairs sensors.AFRICA's monitoring network with localised weather alerts, so a warning
+          reaches the beach before the squall does.
+        </p>
+        <div class="byline">
+          <span>sensors.AFRICA initiative</span><span class="sep">·</span>
+          <span>with Code for Africa</span><span class="sep">·</span>
+          <span>Early-warning system</span>
+        </div>
+        <span class="read-cue">Read on Medium →</span>
+      </div>
+    </a>
+  </div>
+</section>
+
+<!-- ============================================================
+     STORY INDEX GRID
+     ============================================================ -->
+<section class="section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">The index</p>
+        <h2 class="display">From the network</h2>
+      </div>
+      <p class="lede">Illustrative story listings for this prototype — written in the spirit of the reporting the network exists to enable.</p>
+    </div>
+
+    <div class="index-grid">
+
+      <a class="story-card" href="https://medium.com/@sensors.AFRICA" rel="noopener">
+        <div class="story-visual" aria-hidden="true">
+          <svg viewBox="0 0 400 148" preserveAspectRatio="none" role="presentation">
+            <rect width="400" height="148" fill="#10141d"></rect>
+            <g opacity="0.9">
+              <rect x="28"  y="96" width="24" height="52"  fill="var(--aqi-moderate)" opacity="0.5"></rect>
+              <rect x="72"  y="70" width="24" height="78"  fill="var(--aqi-sensitive)" opacity="0.55"></rect>
+              <rect x="116" y="38" width="24" height="110" fill="var(--aqi-unhealthy)" opacity="0.6"></rect>
+              <rect x="160" y="20" width="24" height="128" fill="var(--aqi-unhealthy)" opacity="0.7"></rect>
+              <rect x="204" y="52" width="24" height="96"  fill="var(--aqi-sensitive)" opacity="0.55"></rect>
+              <rect x="248" y="84" width="24" height="64"  fill="var(--aqi-moderate)" opacity="0.5"></rect>
+              <rect x="292" y="104" width="24" height="44" fill="var(--aqi-good)" opacity="0.5"></rect>
+              <rect x="336" y="112" width="24" height="36" fill="var(--aqi-good)" opacity="0.45"></rect>
+            </g>
+            <line x1="20" y1="60" x2="380" y2="60" stroke="var(--aqi-good)" stroke-width="1.5" stroke-dasharray="6 5" opacity="0.7"></line>
+          </svg>
+        </div>
+        <div class="story-body">
+          <div class="tagline-row">
+            <span class="story-tag t-air">Air quality</span>
+            <span class="story-place">Lagos</span>
+          </div>
+          <h3>Two Lagos neighbourhoods, one sky, very different air</h3>
+          <p class="deck">Sensors ten kilometres apart tell two stories: the mainland corridor where generators never sleep, and the island streets that catch the sea breeze. A block-by-block map of who breathes what.</p>
+          <div class="byline"><span>Illustrative story</span><span class="sep">·</span><span>8 min read</span></div>
+          <span class="read-cue">Read on Medium →</span>
+        </div>
+      </a>
+
+      <a class="story-card" href="https://medium.com/@sensors.AFRICA" rel="noopener">
+        <div class="story-visual" aria-hidden="true">
+          <svg viewBox="0 0 400 148" preserveAspectRatio="none" role="presentation">
+            <rect width="400" height="148" fill="#10141d"></rect>
+            <g fill="none" stroke-width="2" stroke-linecap="round">
+              <path d="M20,110 C70,104 100,66 150,72 S250,44 300,58 S360,42 380,48" stroke="var(--aqi-sensitive)" opacity="0.85"></path>
+              <path d="M20,124 C80,118 130,96 190,100 S300,84 380,92" stroke="var(--aqi-good)" opacity="0.55"></path>
+            </g>
+            <!-- school bell marker -->
+            <circle cx="150" cy="72" r="5" fill="var(--aqi-sensitive)"></circle>
+            <circle cx="150" cy="72" r="11" fill="none" stroke="var(--aqi-sensitive)" stroke-width="1" opacity="0.5"></circle>
+            <line x1="20" y1="132" x2="380" y2="132" stroke="rgba(255,255,255,0.15)"></line>
+          </svg>
+        </div>
+        <div class="story-body">
+          <div class="tagline-row">
+            <span class="story-tag t-health">Health</span>
+            <span class="story-place">Nairobi</span>
+          </div>
+          <h3>The school run happens at rush hour — and the sensors can prove it</h3>
+          <p class="deck">Morning readings outside five Nairobi schools spike exactly when the gates open. What hyper-local data says about children's exposure, and what parents are doing with it.</p>
+          <div class="byline"><span>Illustrative story</span><span class="sep">·</span><span>6 min read</span></div>
+          <span class="read-cue">Read on Medium →</span>
+        </div>
+      </a>
+
+      <a class="story-card" href="https://medium.com/@sensors.AFRICA" rel="noopener">
+        <div class="story-visual" aria-hidden="true">
+          <svg viewBox="0 0 400 148" preserveAspectRatio="none" role="presentation">
+            <rect width="400" height="148" fill="#10141d"></rect>
+            <!-- harmattan dust wash -->
+            <path d="M0,148 L0,84 Q100,60 200,78 T400,66 L400,148 Z" fill="var(--aqi-hazardous)" opacity="0.22"></path>
+            <path d="M0,148 L0,108 Q120,88 240,102 T400,94 L400,148 Z" fill="var(--aqi-unhealthy)" opacity="0.28"></path>
+            <g fill="var(--aqi-moderate)" opacity="0.5">
+              <circle cx="70" cy="52" r="2"></circle><circle cx="140" cy="38" r="1.5"></circle>
+              <circle cx="220" cy="56" r="2"></circle><circle cx="300" cy="34" r="1.5"></circle>
+              <circle cx="350" cy="52" r="2"></circle><circle cx="180" cy="26" r="1.5"></circle>
+            </g>
+          </svg>
+        </div>
+        <div class="story-body">
+          <div class="tagline-row">
+            <span class="story-tag t-climate">Climate</span>
+            <span class="story-place">Kano</span>
+          </div>
+          <h3>When the harmattan arrives, Kano's readings go off the chart</h3>
+          <p class="deck">Seasonal dust pushes PM2.5 past 150 µg/m³ for days at a time. Tracking a weather system the network sees coming — and what a dust-season health advisory could look like.</p>
+          <div class="byline"><span>Illustrative story</span><span class="sep">·</span><span>7 min read</span></div>
+          <span class="read-cue">Read on Medium →</span>
+        </div>
+      </a>
+
+      <a class="story-card" href="https://medium.com/@sensors.AFRICA" rel="noopener">
+        <div class="story-visual" aria-hidden="true">
+          <svg viewBox="0 0 400 148" preserveAspectRatio="none" role="presentation">
+            <rect width="400" height="148" fill="#10141d"></rect>
+            <!-- e-waste site: smoke plumes -->
+            <g fill="none" stroke-width="2" stroke-linecap="round" opacity="0.75">
+              <path d="M110,140 C104,110 122,96 112,70 C104,50 118,38 114,22" stroke="var(--aqi-veryunhealthy)"></path>
+              <path d="M200,140 C194,114 212,100 202,74 C194,54 208,42 204,26" stroke="var(--aqi-veryunhealthy)" opacity="0.6"></path>
+              <path d="M290,140 C284,116 302,104 292,80" stroke="var(--aqi-veryunhealthy)" opacity="0.4"></path>
+            </g>
+            <line x1="20" y1="140" x2="380" y2="140" stroke="rgba(255,255,255,0.2)" stroke-width="2"></line>
+          </svg>
+        </div>
+        <div class="story-body">
+          <div class="tagline-row">
+            <span class="story-tag t-invest">Investigation</span>
+            <span class="story-place">Accra</span>
+          </div>
+          <h3>Downwind of the burn: tracing smoke from an e-waste yard</h3>
+          <p class="deck">Residents said the smoke reached their homes. Officials said it didn't. Three citizen-hosted sensors, six weeks of readings, and a wind-direction chart settled the argument.</p>
+          <div class="byline"><span>Illustrative story</span><span class="sep">·</span><span>11 min read</span></div>
+          <span class="read-cue">Read on Medium →</span>
+        </div>
+      </a>
+
+      <a class="story-card" href="https://medium.com/@sensors.AFRICA" rel="noopener">
+        <div class="story-visual" aria-hidden="true">
+          <svg viewBox="0 0 400 148" preserveAspectRatio="none" role="presentation">
+            <rect width="400" height="148" fill="#10141d"></rect>
+            <!-- sensor host: house + device + signal -->
+            <g stroke="#e9ebf0" stroke-width="2" fill="none" opacity="0.8" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M140,120 L140,72 L200,40 L260,72 L260,120 Z"></path>
+              <rect x="186" y="88" width="28" height="32"></rect>
+            </g>
+            <rect x="264" y="60" width="10" height="18" rx="2" fill="var(--aqi-good)"></rect>
+            <g stroke="var(--aqi-good)" fill="none" stroke-width="1.5" opacity="0.7" stroke-linecap="round">
+              <path d="M282,62 q8,7 0,14"></path>
+              <path d="M290,56 q14,13 0,26"></path>
+              <path d="M298,50 q20,19 0,38"></path>
+            </g>
+            <line x1="60" y1="126" x2="340" y2="126" stroke="rgba(255,255,255,0.15)"></line>
+          </svg>
+        </div>
+        <div class="story-body">
+          <div class="tagline-row">
+            <span class="story-tag t-air">Air quality</span>
+            <span class="story-place">Dar es Salaam</span>
+          </div>
+          <h3>The retired teacher whose balcony became a public record</h3>
+          <p class="deck">One SDS011 sensor, one window ledge, eighteen months of open data. How a single citizen host turned her street into the best-documented air in the neighbourhood.</p>
+          <div class="byline"><span>Illustrative story</span><span class="sep">·</span><span>5 min read</span></div>
+          <span class="read-cue">Read on Medium →</span>
+        </div>
+      </a>
+
+      <a class="story-card" href="https://medium.com/@sensors.AFRICA" rel="noopener">
+        <div class="story-visual" aria-hidden="true">
+          <svg viewBox="0 0 400 148" preserveAspectRatio="none" role="presentation">
+            <rect width="400" height="148" fill="#10141d"></rect>
+            <!-- data table / ledger motif -->
+            <g stroke="rgba(255,255,255,0.14)" stroke-width="1">
+              <line x1="40" y1="36" x2="360" y2="36"></line>
+              <line x1="40" y1="64" x2="360" y2="64"></line>
+              <line x1="40" y1="92" x2="360" y2="92"></line>
+              <line x1="40" y1="120" x2="360" y2="120"></line>
+            </g>
+            <g>
+              <rect x="40" y="44" width="120" height="8" rx="4" fill="var(--aqi-good)" opacity="0.55"></rect>
+              <rect x="40" y="72" width="200" height="8" rx="4" fill="var(--aqi-moderate)" opacity="0.55"></rect>
+              <rect x="40" y="100" width="260" height="8" rx="4" fill="var(--aqi-unhealthy)" opacity="0.6"></rect>
+            </g>
+            <circle cx="336" cy="104" r="9" fill="none" stroke="var(--aqi-unhealthy)" stroke-width="2" opacity="0.8"></circle>
+          </svg>
+        </div>
+        <div class="story-body">
+          <div class="tagline-row">
+            <span class="story-tag t-invest">Investigation</span>
+            <span class="story-place">Nairobi</span>
+          </div>
+          <h3>The city said the air was fine. The archive disagreed.</h3>
+          <p class="deck">When an official statement cited "normal" pollution levels, watchdogs pulled the open archive: 47 sensitive-band days in one quarter. A short anatomy of accountability by CSV.</p>
+          <div class="byline"><span>Illustrative story</span><span class="sep">·</span><span>9 min read</span></div>
+          <span class="read-cue">Read on Medium →</span>
+        </div>
+      </a>
+
+    </div>
+
+    <!-- Medium CTA band -->
+    <div class="medium-band">
+      <div class="medium-left">
+        <div class="medium-mark" aria-hidden="true">M</div>
+        <div>
+          <h3>Read more on Medium</h3>
+          <p>Our reporting, deployment diaries and methodology notes are published openly. Follow sensors.AFRICA for new dispatches from the network.</p>
+        </div>
+      </div>
+      <a class="btn btn-primary" href="https://medium.com/@sensors.AFRICA" rel="noopener">Read more on Medium</a>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     STAY UPDATED — newsletter + trailheads to data/air
+     ============================================================ -->
+<section class="section updates-section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <div class="section-head">
+      <div>
+        <p class="kicker">Stay with the story</p>
+        <h2 class="display">Follow the evidence</h2>
+      </div>
+    </div>
+    <div class="updates-grid">
+      <div class="newsletter-card">
+        <h3>Dispatches, monthly</h3>
+        <p>New investigations, notable readings and network milestones — one email a month, no noise.</p>
+        <form class="newsletter-form" id="newsletter-form" aria-label="Newsletter sign-up (prototype)">
+          <label for="nl-email" class="kicker" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0)">Email address</label>
+          <input type="email" id="nl-email" name="email" placeholder="you@example.com" autocomplete="email" required>
+          <button type="submit">Subscribe</button>
+        </form>
+        <p class="newsletter-confirm" id="newsletter-confirm" role="status">Prototype only — no email was sent or stored. Thanks for trying it.</p>
+        <p class="newsletter-note">Prototype sign-up — this form doesn't submit anywhere yet.</p>
+      </div>
+      <div class="trailheads">
+        <a class="trail-card" href="data.html">
+          <span class="kicker">Open data</span>
+          <h4>Interrogate the archive yourself</h4>
+          <p>Every story here starts in the open data. Download, query and verify the readings behind the reporting.</p>
+          <span class="go" aria-hidden="true">→</span>
+        </a>
+        <a class="trail-card" href="air.html">
+          <span class="kicker">Live network</span>
+          <h4>See what the air says right now</h4>
+          <p>The live PM<sub>2.5</sub> and PM<sub>10</sub> map — the raw material for the next story.</p>
+          <span class="go" aria-hidden="true">→</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+
+</main>
+
+<!-- ============================================================
+     FOOTER
+     ============================================================ -->
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+        <p class="footer-mission">A pan-African citizen science initiative using sensors to monitor air, water and sound pollution — giving citizens actionable information about their cities.</p>
+      </div>
+      <div class="footer-col">
+        <h4>Network</h4>
+        <ul>
+          <li><a href="air.html">Air quality</a></li>
+          <li><a href="water.html">Water</a></li>
+          <li><a href="sound.html">Sound</a></li>
+          <li><a href="radiation.html">Radiation</a></li>
+          <li><a href="data.html">Open data</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Community</h4>
+        <ul>
+          <li><a href="stories.html">Stories</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="get-started.html">Get a sensor</a></li>
+          <li><a href="https://twitter.com/sensorsAFRICA/" rel="noopener">Twitter</a></li>
+          <li><a href="https://www.instagram.com/sensorsAFRICA/" rel="noopener">Instagram</a></li>
+          <li><a href="https://medium.com/@sensors.AFRICA" rel="noopener">Medium</a></li>
+          <li><a href="https://github.com/CodeForAfrica/sensors.AFRICA" rel="noopener">GitHub</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Partners</h4>
+        <ul>
+          <li><a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a></li>
+          <li><a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a></li>
+          <li><a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>Incubated by <a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a> · seed-funded by <a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a> · powered by <a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></span>
+      <span>Redesign prototype — illustrative story listings. StormWatch is a real sensors.AFRICA initiative; other headlines are sample editorial.</span>
+    </div>
+  </div>
+</footer>
+
+<!-- ============================================================
+     SCRIPT — newsletter prototype behaviour (progressive
+     enhancement only; page is complete without it)
+     ============================================================ -->
+<script>
+try {
+  var form = document.getElementById('newsletter-form');
+  var confirmMsg = document.getElementById('newsletter-confirm');
+  if (form && confirmMsg) {
+    form.addEventListener('submit', function (e) {
+      e.preventDefault(); // prototype: never actually submit anywhere
+      confirmMsg.style.display = 'block';
+      var input = document.getElementById('nl-email');
+      if (input) input.value = '';
+    });
+  }
+} catch (err) {
+  console.warn('Newsletter enhancement skipped:', err && err.message);
+}
+</script>
+
+</body>
+</html>

--- a/redesign/water.html
+++ b/redesign/water.html
@@ -1,0 +1,434 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Water — coming soon · sensors.AFRICA</title>
+<meta name="description" content="sensors.AFRICA is preparing a water-quality monitoring stream: low-cost sensors tracking the safety of the water African communities drink. Coming soon — air is our live network today.">
+
+<!-- Fonts: Fraunces (display serif) · Space Grotesk (data) · Inter (body) -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Space+Grotesk:wght@400;500;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+
+<style>
+/* ============================================================
+   TOKENS — shared with all subpages, do not diverge
+   ============================================================ */
+:root{
+  --ink:#0c0f16; --ink-2:#141821; --ink-3:#1a1f2b;
+  --paper:#f1eee7; --paper-ink:#17140f;
+  --text:#e9ebf0; --text-2:#9aa2b1; --muted:#6b7280;
+  --hair:rgba(255,255,255,0.09); --hair-strong:rgba(255,255,255,0.16);
+  --aqi-good:#46d17f; --aqi-moderate:#f4c542; --aqi-sensitive:#f5822e;
+  --aqi-unhealthy:#ef5350; --aqi-veryunhealthy:#b06ae0; --aqi-hazardous:#c0466c;
+  --serif:"Fraunces",Georgia,serif;
+  --sans:"Inter",system-ui,-apple-system,sans-serif;
+  --data:"Space Grotesk","Inter",system-ui,sans-serif;
+  --maxw:1200px;
+  /* page accent — WATER (cool aqua, matches the landing stream card) */
+  --accent:#4fa8d8; --accent-soft:rgba(79,168,216,.12); --accent-hover:#6fbce4;
+}
+
+/* ============================================================
+   BASE
+   ============================================================ */
+*{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  background:var(--ink); color:var(--text);
+  font-family:var(--sans); font-size:16px; line-height:1.6;
+  -webkit-font-smoothing:antialiased;
+}
+img{max-width:100%;display:block}
+a{color:inherit}
+:focus-visible{outline:2px solid var(--aqi-moderate);outline-offset:3px;border-radius:2px}
+::selection{background:var(--accent);color:var(--ink)}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
+.kicker{
+  font-family:var(--data);font-size:.75rem;font-weight:500;
+  letter-spacing:.18em;text-transform:uppercase;color:var(--text-2);
+}
+h2.display{
+  font-family:var(--serif);font-weight:600;font-size:clamp(1.7rem,3.4vw,2.6rem);
+  line-height:1.12;letter-spacing:-.01em;margin:10px 0 14px;
+}
+
+/* The AQI spine — a segmented band used as the site's structural accent */
+.aqi-spine{display:flex;height:4px;width:100%}
+.aqi-spine span{flex:1}
+.aqi-spine .s1{background:var(--aqi-good)}
+.aqi-spine .s2{background:var(--aqi-moderate)}
+.aqi-spine .s3{background:var(--aqi-sensitive)}
+.aqi-spine .s4{background:var(--aqi-unhealthy)}
+.aqi-spine .s5{background:var(--aqi-veryunhealthy)}
+.aqi-spine .s6{background:var(--aqi-hazardous)}
+.spine-sm{width:64px;height:4px;margin-bottom:14px}
+
+/* ============================================================
+   HEADER — identical shell across the site
+   ============================================================ */
+.site-header{
+  position:sticky;top:0;z-index:1000;
+  background:rgba(12,15,22,.88);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+  border-bottom:1px solid var(--hair);
+}
+.header-inner{
+  max-width:var(--maxw);margin:0 auto;padding:0 24px;
+  display:flex;align-items:center;justify-content:space-between;gap:20px;height:64px;
+}
+.wordmark{
+  font-family:var(--data);font-weight:700;font-size:1.05rem;letter-spacing:.01em;
+  text-decoration:none;white-space:nowrap;
+}
+.wordmark .dot-africa{color:var(--aqi-good)}
+.main-nav{display:flex;gap:2px;align-items:center;overflow-x:auto}
+.main-nav a{
+  font-family:var(--data);font-size:.82rem;font-weight:500;color:var(--text-2);
+  text-decoration:none;padding:8px 11px;border-radius:6px;white-space:nowrap;
+}
+.main-nav a:hover{color:var(--text);background:var(--ink-3)}
+.main-nav a[aria-current="page"]{color:var(--text);background:var(--ink-3)}
+.main-nav a.live-link{color:var(--text)}
+.main-nav a.live-link::before{
+  content:"";display:inline-block;width:6px;height:6px;border-radius:50%;
+  background:var(--aqi-good);margin-right:7px;vertical-align:1px;
+}
+.nav-cta{
+  font-family:var(--data);font-size:.82rem;font-weight:700;text-decoration:none;
+  color:var(--ink);background:var(--aqi-good);padding:9px 16px;border-radius:999px;white-space:nowrap;
+}
+.nav-cta:hover{background:#5fdd92}
+
+/* ============================================================
+   HERO — coming-soon data-stream layout (shared template)
+   ============================================================ */
+.hero{position:relative;overflow:hidden;border-bottom:1px solid var(--hair)}
+.hero::before{ /* faint accent wash */
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:
+    radial-gradient(52rem 30rem at 78% -10%, var(--accent-soft), transparent 60%),
+    radial-gradient(44rem 26rem at 8% 110%, rgba(70,209,127,.05), transparent 60%);
+}
+.hero-grid{
+  position:relative;display:grid;grid-template-columns:minmax(0,1.15fr) minmax(0,.85fr);
+  gap:56px;align-items:center;padding:76px 0 68px;
+}
+.hero h1{
+  font-family:var(--serif);font-weight:640;font-variation-settings:"opsz" 100;
+  font-size:clamp(2.5rem,5.4vw,4.3rem);line-height:1.04;letter-spacing:-.015em;
+}
+.hero h1 em{font-style:italic;font-weight:520;color:var(--accent)}
+.hero .standfirst{margin-top:22px;font-size:1.08rem;color:var(--text-2);max-width:52ch}
+.hero-actions{margin-top:30px;display:flex;gap:14px;flex-wrap:wrap;align-items:center}
+.btn{
+  font-family:var(--data);font-weight:700;font-size:.92rem;text-decoration:none;
+  padding:13px 24px;border-radius:999px;display:inline-block;
+}
+.btn-accent{background:var(--accent);color:var(--ink)}
+.btn-accent:hover{background:var(--accent-hover)}
+.btn-ghost{color:var(--text);border:1px solid var(--hair-strong)}
+.btn-ghost:hover{border-color:var(--text-2)}
+.proto-badge{
+  display:inline-flex;align-items:center;gap:7px;margin-top:26px;
+  font-family:var(--data);font-size:.68rem;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--muted);border:1px solid var(--hair);border-radius:999px;padding:5px 12px;
+}
+.proto-badge::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--aqi-moderate)}
+
+/* honest status badge — this stream is not live yet */
+.soon-badge{
+  display:inline-flex;align-items:center;gap:9px;margin-bottom:22px;
+  font-family:var(--data);font-size:.72rem;font-weight:700;letter-spacing:.16em;text-transform:uppercase;
+  color:var(--accent);border:1px solid var(--accent);border-radius:999px;padding:7px 16px;
+}
+.soon-badge::before{content:"";width:7px;height:7px;border-radius:50%;border:2px solid var(--accent)}
+.live-note{margin-top:14px;font-family:var(--data);font-size:.8rem;color:var(--muted)}
+.live-note a{color:var(--text-2)}
+.live-note a:hover{color:var(--text)}
+
+/* Preview panel — planned metrics, deliberately shown without data */
+.preview-panel{
+  position:relative;background:var(--ink-2);border:1px solid var(--hair-strong);
+  border-radius:16px;padding:26px 28px 24px;box-shadow:0 24px 60px rgba(0,0,0,.45);
+}
+.preview-panel .panel-accent{
+  position:absolute;top:0;left:0;right:0;height:4px;
+  border-radius:16px 16px 0 0;background:var(--accent);
+}
+.panel-top{display:flex;justify-content:space-between;align-items:baseline;gap:12px;margin-top:6px}
+.panel-title{font-family:var(--serif);font-size:1.4rem;font-weight:600}
+.panel-status{
+  font-family:var(--data);font-size:.66rem;letter-spacing:.14em;text-transform:uppercase;
+  color:var(--muted);border:1px solid var(--hair);border-radius:999px;padding:4px 11px;white-space:nowrap;
+}
+.metric-list{list-style:none;margin-top:20px}
+.metric-list li{
+  display:flex;justify-content:space-between;align-items:baseline;gap:14px;
+  padding:11px 0;border-bottom:1px solid var(--hair);
+  font-family:var(--data);font-size:.88rem;
+}
+.metric-list li:last-child{border-bottom:0}
+.metric-list .m{color:var(--text-2)}
+.metric-list .v{color:var(--muted);font-variant-numeric:tabular-nums;letter-spacing:.08em}
+.metric-list .u{color:var(--muted);font-size:.72rem;margin-left:6px}
+.panel-foot{
+  margin-top:14px;padding-top:14px;border-top:1px solid var(--hair);
+  font-family:var(--data);font-size:.72rem;color:var(--muted);
+}
+
+/* ============================================================
+   PAPER SECTION — why it matters (warm reading surface)
+   ============================================================ */
+.section{padding:84px 0}
+.paper-section{background:var(--paper);color:var(--paper-ink)}
+.paper-section .kicker{color:#6d675c}
+.paper-section h2.display{color:var(--paper-ink)}
+.impact-grid{display:grid;grid-template-columns:1.1fr .9fr;gap:56px;align-items:start;margin-top:20px}
+.impact-prose{font-family:var(--serif);font-size:1.16rem;line-height:1.72;color:#2c2820;font-weight:420}
+.impact-prose p+p{margin-top:1.1em}
+.impact-prose strong{font-weight:640;color:var(--paper-ink)}
+.stat-tiles{display:grid;grid-template-columns:1fr;gap:14px}
+.stat-tile{background:#fff;border:1px solid #e2ddd1;border-radius:12px;padding:20px 20px 18px}
+.stat-tile .val{font-family:var(--data);font-weight:700;font-size:2.1rem;line-height:1.1;color:var(--paper-ink)}
+.stat-tile .lbl{font-size:.8rem;color:#6d675c;margin-top:6px;line-height:1.45}
+.stat-tile .bar{height:4px;border-radius:2px;background:#ece8dd;margin-top:14px;overflow:hidden}
+.stat-tile .bar i{display:block;height:100%;border-radius:2px}
+.paper-credit{margin-top:34px;font-family:var(--data);font-size:.74rem;color:#8a8375}
+
+/* ============================================================
+   CTA — notify me / stay updated
+   ============================================================ */
+.cta-section{position:relative;overflow:hidden;border-top:1px solid var(--hair)}
+.cta-section::before{
+  content:"";position:absolute;inset:0;pointer-events:none;
+  background:radial-gradient(50rem 26rem at 50% 120%, var(--accent-soft), transparent 65%);
+}
+.cta-inner{position:relative;text-align:center;padding:96px 24px;max-width:760px;margin:0 auto}
+.cta-inner h2{
+  font-family:var(--serif);font-weight:640;font-size:clamp(2rem,4.4vw,3.3rem);
+  line-height:1.08;letter-spacing:-.015em;
+}
+.cta-inner p{margin:20px auto 32px;color:var(--text-2);max-width:46ch}
+.cta-inner .aqi-spine{width:120px;margin:0 auto 28px}
+.cta-proto{margin-top:30px;font-family:var(--data);font-size:.74rem;color:var(--muted)}
+
+/* ============================================================
+   FOOTER — identical shell across the site
+   ============================================================ */
+.site-footer{background:#080a10;border-top:1px solid var(--hair);padding:64px 0 40px}
+.footer-grid{display:grid;grid-template-columns:1.4fr 1fr 1fr 1fr;gap:40px}
+.footer-mission{font-size:.9rem;color:var(--text-2);margin-top:14px;max-width:38ch}
+.footer-col h4{
+  font-family:var(--data);font-size:.66rem;font-weight:700;letter-spacing:.16em;
+  text-transform:uppercase;color:var(--muted);margin-bottom:16px;
+}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:9px}
+.footer-col a{font-size:.88rem;color:var(--text-2);text-decoration:none}
+.footer-col a:hover{color:var(--text)}
+.footer-bottom{
+  margin-top:52px;padding-top:22px;border-top:1px solid var(--hair);
+  display:flex;justify-content:space-between;gap:14px;flex-wrap:wrap;
+  font-family:var(--data);font-size:.74rem;color:var(--muted);
+}
+.footer-bottom a{color:var(--text-2)}
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width:1020px){
+  .footer-grid{grid-template-columns:1fr 1fr}
+  .impact-grid{grid-template-columns:1fr;gap:36px}
+}
+@media (max-width:820px){
+  .hero-grid{grid-template-columns:1fr;gap:40px;padding:56px 0}
+  .main-nav{display:none}
+}
+@media (max-width:600px){
+  .footer-grid{grid-template-columns:1fr}
+  .section{padding:60px 0}
+}
+
+/* ============================================================
+   REDUCED MOTION
+   ============================================================ */
+@media (prefers-reduced-motion:reduce){
+  html{scroll-behavior:auto}
+}
+</style>
+</head>
+<body>
+
+<!-- ============================================================
+     HEADER
+     ============================================================ -->
+<header class="site-header">
+  <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+  <div class="header-inner">
+    <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+    <nav class="main-nav" aria-label="Primary">
+      <a class="live-link" href="air.html">Air</a>
+      <a href="water.html" aria-current="page">Water</a>
+      <a href="sound.html">Sound</a>
+      <a href="radiation.html">Radiation</a>
+      <a href="data.html">Data</a>
+      <a href="stories.html">Stories</a>
+      <a href="about.html">About</a>
+    </nav>
+    <a class="nav-cta" href="get-started.html">Get a sensor</a>
+  </div>
+</header>
+
+<main>
+
+<!-- ============================================================
+     HERO — coming-soon stream
+     ============================================================ -->
+<section class="hero">
+  <div class="wrap hero-grid">
+    <div>
+      <p class="kicker" style="margin-bottom:18px">Monitoring stream &middot; Water</p>
+      <span class="soon-badge">Coming soon</span>
+      <h1>What's in the water? <em>Soon: a public answer.</em></h1>
+      <p class="standfirst">
+        We're preparing a water-quality stream for the sensors.AFRICA network: low-cost,
+        citizen-hosted sensors and field test kits tracking the safety of the water African
+        communities drink, cook with and give to their children. This stream is not live yet —
+        we're publishing our plans openly while we build it.
+      </p>
+      <div class="hero-actions">
+        <a class="btn btn-accent" href="https://docs.google.com/forms/d/e/1FAIpQLSdYwUWsyj5VQggCmpVh4O92VWt6NQ-J6kX-jN7uAa1FOELq0w/viewform" rel="noopener">Notify me when it launches</a>
+        <a class="btn btn-ghost" href="air.html">See the live Air network →</a>
+      </div>
+      <p class="live-note">Air is our only live stream today. Every reading on <a href="air.html">the Air network</a> is real, open and citizen-collected.</p>
+      <span class="proto-badge">Prototype &middot; concept page</span>
+    </div>
+
+    <!-- Planned-metrics panel: honest placeholder, no fake readings -->
+    <aside class="preview-panel" aria-label="Planned water-quality metrics — no live data yet">
+      <div class="panel-accent" aria-hidden="true"></div>
+      <div class="panel-top">
+        <span class="panel-title">Planned measurements</span>
+        <span class="panel-status">No live data yet</span>
+      </div>
+      <ul class="metric-list">
+        <li><span class="m">Turbidity</span><span class="v">— · —<span class="u">NTU</span></span></li>
+        <li><span class="m">pH</span><span class="v">— · —<span class="u">pH</span></span></li>
+        <li><span class="m">Electrical conductivity</span><span class="v">— · —<span class="u">µS/cm</span></span></li>
+        <li><span class="m">Bacterial indicators (E.&nbsp;coli)</span><span class="v">— · —<span class="u">CFU/100&nbsp;ml</span></span></li>
+        <li><span class="m">Water temperature</span><span class="v">— · —<span class="u">°C</span></span></li>
+      </ul>
+      <p class="panel-foot">Candidate indicators under evaluation with partners — the final sensor kit and methodology will be published openly before launch.</p>
+    </aside>
+  </div>
+</section>
+
+<!-- ============================================================
+     WHY IT MATTERS — warm-paper reading block
+     ============================================================ -->
+<section class="section paper-section">
+  <div class="wrap">
+    <div class="aqi-spine spine-sm" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <p class="kicker">Why water, why now</p>
+    <h2 class="display">Contaminated drinking water is a quiet, counted killer</h2>
+    <div class="impact-grid">
+      <div class="impact-prose">
+        <p>
+          The Global Burden of Disease study attributes roughly <strong>642,486 deaths every
+          year</strong> to contaminated drinking water — most of them from diarrhoeal disease, and
+          a disproportionate share of them children in low-income countries. Unlike a smoggy
+          skyline, unsafe water rarely announces itself: it looks clear, and the harm shows up
+          later, in clinics.
+        </p>
+        <p>
+          Across much of Africa, the water people actually drink — from taps, boreholes, kiosks
+          and rivers — is tested rarely, and the results are almost never public. This stream will
+          change that pattern the same way our air network did: <strong>put low-cost instruments in
+          the hands of citizens, and publish what they find as open data</strong> — for the parent
+          filling a jerrycan, the journalist chasing a cholera outbreak, and the utility defending
+          (or failing to defend) its pipes.
+        </p>
+      </div>
+      <div class="stat-tiles" aria-label="Key figures on unsafe drinking water">
+        <div class="stat-tile">
+          <div class="val">≈642,486</div>
+          <div class="lbl">deaths per year attributed to contaminated drinking water — Global Burden of Disease study</div>
+          <div class="bar" aria-hidden="true"><i style="width:82%;background:var(--accent)"></i></div>
+        </div>
+        <div class="stat-tile">
+          <div class="val">0 — for now</div>
+          <div class="lbl">independent, openly published water-quality readings in our network today. That's the gap this stream exists to close.</div>
+          <div class="bar" aria-hidden="true"><i style="width:4%;background:var(--aqi-unhealthy)"></i></div>
+        </div>
+      </div>
+    </div>
+    <p class="paper-credit">Mortality figure: Global Burden of Disease study (contaminated drinking water). This page describes planned work — no water readings are being published yet.</p>
+  </div>
+</section>
+
+<!-- ============================================================
+     CTA — stay updated
+     ============================================================ -->
+<section class="cta-section">
+  <div class="cta-inner">
+    <div class="aqi-spine" aria-hidden="true"><span class="s1"></span><span class="s2"></span><span class="s3"></span><span class="s4"></span><span class="s5"></span><span class="s6"></span></div>
+    <h2>Be there when the first reading goes public.</h2>
+    <p>Leave your details and we'll tell you when the water stream launches — and how to host a sensor or join a field-testing pilot in your community.</p>
+    <a class="btn btn-accent" href="https://docs.google.com/forms/d/e/1FAIpQLSdYwUWsyj5VQggCmpVh4O92VWt6NQ-J6kX-jN7uAa1FOELq0w/viewform" rel="noopener">Stay updated — join the list</a>
+    <p class="cta-proto">Prototype — this is a concept page for the sensors.AFRICA redesign. The water stream is not yet live. Meanwhile, <a href="air.html" style="color:var(--text-2)">explore live air data</a>.</p>
+  </div>
+</section>
+
+</main>
+
+<!-- ============================================================
+     FOOTER
+     ============================================================ -->
+<footer class="site-footer">
+  <div class="wrap">
+    <div class="footer-grid">
+      <div>
+        <a class="wordmark" href="index.html">sensors<span class="dot-africa">.AFRICA</span></a>
+        <p class="footer-mission">A pan-African citizen science initiative using sensors to monitor air, water and sound pollution — giving citizens actionable information about their cities.</p>
+      </div>
+      <div class="footer-col">
+        <h4>Network</h4>
+        <ul>
+          <li><a href="air.html">Air quality</a></li>
+          <li><a href="water.html">Water</a></li>
+          <li><a href="sound.html">Sound</a></li>
+          <li><a href="radiation.html">Radiation</a></li>
+          <li><a href="data.html">Open data</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Community</h4>
+        <ul>
+          <li><a href="stories.html">Stories</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="get-started.html">Get a sensor</a></li>
+          <li><a href="https://twitter.com/sensorsAFRICA/" rel="noopener">Twitter</a></li>
+          <li><a href="https://www.instagram.com/sensorsAFRICA/" rel="noopener">Instagram</a></li>
+          <li><a href="https://medium.com/@sensors.AFRICA" rel="noopener">Medium</a></li>
+          <li><a href="https://github.com/CodeForAfrica/sensors.AFRICA" rel="noopener">GitHub</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Partners</h4>
+        <ul>
+          <li><a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a></li>
+          <li><a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a></li>
+          <li><a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <span>Incubated by <a href="https://codeforafrica.org/" rel="noopener">Code for Africa</a> · seed-funded by <a href="https://innovateafrica.fund/" rel="noopener">innovateAFRICA</a> · powered by <a href="https://luftdaten.info/" rel="noopener">Luftdaten</a></span>
+      <span>Redesign prototype — the water stream is not yet live; this page describes planned work.</span>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
Self-contained static HTML prototype exploring a newsroom-style redesign where live air-quality data is the subject. Nine pages under redesign/, sharing one design system (Fraunces/Space Grotesk/Inter, AQI health-scale palette on a deep-ink surface with warm-paper reading sections):

- index.html        Landing: hero live reading, city ticker, Leaflet map,
                    24h PM2.5 trend chart, four monitoring streams
- air.html          Flagship air stream: city dashboard, 24h trend chart,
                    16-city ranked comparison, map, AQI health guidance
- water/sound/radiation.html   Coming-soon stream concept pages
- about.html        Mission, projects, partners, team, coverage
- stories.html      Editorial story index (StormWatch featured)
- data.html         Open-data hub: embeddable widgets, API, archives
- get-started.html  Join the network: pathways, hardware, FAQ

Charts are hand-authored inline SVG, fully visible without JS; map/chart/ ticker scripts are isolated with try/catch. Responsive and accessible (semantic HTML, focus states, prefers-reduced-motion). All readings are labelled illustrative sample data.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots
<img width="395" height="1999" alt="image-1784043492712" src="https://github.com/user-attachments/assets/b52768fa-6444-4987-a632-03e65cb5f206" />

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
